### PR TITLE
Tarjan network refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ We use [`pixi`](https://github.com/prefix-dev/pixi) as the package manager.
 pixi shell # to activate the env
 ```
 
+If you want to use [`micromamba`](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html) as the package manager, create and activate 
+the environment.
+
+```bash
+micromamba create -f environment.yml
+micromamba activate seldonenv
+```
+
 ### Compilation
 
 We use `meson` to compile and build Seldon. 
@@ -26,9 +34,9 @@ meson compile -C build
 ### Quick Start 
 
 Run the executable, and provide the input configuration TOML file (as the first
-positional argument), and an optional output directory parent location. If the output location is not specified, it is set to the parent directory in which the config file is present
+positional argument), and an optional output directory location. If the output location is not specified, it is set to the parent directory in which the config file is present
 
 ```bash
 cd build
-./seldon /path/to/config -o /path/to/parent/output/dir
+./seldon /path/to/config -o /path/to/output/dir
 ``` 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,20 @@
+# $ micromamba create -f environment.yml
+# $ micromamba activate seldonenv
+#
+
+name: seldonenv
+channels:
+  - conda-forge
+# requirements:
+#   build:
+#     - {{ compiler('c') }}
+#     - {{ compiler('c++') }}
+dependencies:
+  - meson
+  - fmt
+  - pkg-config
+  - cmake
+  - ninja 
+  - cpp-argparse
+  - clang-format
+  - tomlplusplus

--- a/include/connectivity.hpp
+++ b/include/connectivity.hpp
@@ -1,0 +1,123 @@
+#pragma once
+#include <tuple>
+#include <vector>
+
+namespace Seldon
+{
+
+class TarjanConnectivityAlgo
+{
+public:
+    TarjanConnectivityAlgo( const std::vector<std::vector<size_t>> & adjacency_list_arg )
+            : scc_list( std::vector<std::vector<size_t>>( 0 ) ),
+              adjacency_list( adjacency_list_arg ),
+              num_nodes( adjacency_list.size() ),
+              num( std::vector<size_t>( num_nodes ) ),
+              lowest( std::vector<size_t>( num_nodes ) ),
+              visited( std::vector<bool>( num_nodes, false ) ),
+              processed( std::vector<bool>( num_nodes, false ) ),
+              stack( std::vector<size_t>( 0 ) ),
+              index_counter( 0 )
+    {
+        run(); // Tarjan's algorithm
+    }
+
+    std::vector<std::vector<size_t>>
+        scc_list; // Each element is a vector of indices corresponding to a strongly connected component (SCC)
+
+private:
+    std::vector<std::vector<size_t>> adjacency_list;
+    int num_nodes;
+    std::vector<size_t> num;     // holding vertex numbers
+    std::vector<size_t> lowest;  // lowest[v] : minimum number of a vertex reachable from v
+    std::vector<bool> visited;   // visited so DFS has seen these vertices (not necessarily processed)
+    std::vector<bool> processed; // vertices which have been processed by DFS
+    std::vector<size_t>
+        stack; // stack of vertices to keep a working set of vertices. Holds all vertices reachable from the starting vertex
+    size_t index_counter; // depth-first search node number counter
+
+    // Depth-first search
+    // v: Current vertex
+    void depth_first_search( std::size_t v )
+    {
+        std::vector<size_t> scc;
+
+        // Set things for the current vertex v
+        num[v]    = index_counter;
+        lowest[v] = num[v];
+        index_counter += 1;
+        visited[v] = true;
+        stack.push_back( v );
+
+        // Loop through neighbours of v
+        // u is the neighbouring vertex
+        for( auto & u : adjacency_list[v] )
+        {
+            // Skip for the element itself
+            if( u == v )
+            {
+                continue;
+            }
+
+            // If u hasn't been visited do a DFS
+            if( !visited[u] )
+            {
+                // recursive call to DFS
+                depth_first_search( u );
+                lowest[v] = std::min( lowest[v], lowest[u] );
+            } // u not visited
+            else
+            {
+                // If u has been processed, then it is a cross-edge and should be ignored.
+                // If u has been visited but not processed:
+                if( !processed[u] )
+                {
+                    lowest[v] = std::min( lowest[v], num[u] );
+                } // u not processed
+            }     // u has been visited
+        }
+
+        // Now v has been processed
+        processed[v] = true;
+
+        // Handle SCC if found
+        if( lowest[v] == num[v] )
+        {
+            scc.resize( 0 );
+            size_t scc_vertex;
+            // Pop the stack
+            scc_vertex = stack.back();
+            stack.pop_back();
+            while( scc_vertex != v )
+            {
+                scc.push_back( scc_vertex ); // Add to the SCC
+                // Pop the stack
+                scc_vertex = stack.back();
+                stack.pop_back();
+            } // unravelling stack
+            // Add the last vertex
+            scc.push_back( scc_vertex );
+            // Now that we have found the SCC, add it
+            // to the SCC list
+            scc_list.push_back( scc );
+        } // SCC found
+    }
+
+    // Actually run Tarjan's algorithm
+    // for finding strongly connected components (SCCs)
+    void run()
+    {
+        // Tarjan's algorithm takes the form of a series of DFS invocations
+        for( size_t i_node = 0; i_node < num_nodes; ++i_node )
+        {
+            // Start from a node that has not been visited
+            if( !visited[i_node] )
+            {
+                // Call the depth first search
+                depth_first_search( i_node );
+            }
+        }
+    }
+};
+
+} // namespace Seldon

--- a/include/network.hpp
+++ b/include/network.hpp
@@ -25,7 +25,7 @@ public:
         gen = std::mt19937( seed.value_or( std::random_device()() ) );
     }
 
-    void get_adjacencies( std::size_t agent_idx, std::vector<size_t> & buffer ) const;
+    void get_neighbours( std::size_t agent_idx, std::vector<size_t> & buffer ) const;
     void get_weights( std::size_t agent_idx, std::vector<double> & buffer ) const;
 
 private:

--- a/include/network.hpp
+++ b/include/network.hpp
@@ -2,7 +2,6 @@
 #include <cstddef>
 #include <optional>
 #include <random>
-#include <tuple>
 #include <vector>
 
 namespace Seldon
@@ -11,15 +10,12 @@ namespace Seldon
 class Network
 {
 public:
-    using edgeT             = std::tuple<size_t, double>;
-    using connectionVectorT = std::vector<edgeT>;
-
     Network() = default;
     Network( std::size_t n_agents, std::size_t n_connections, std::optional<int> seed = std::nullopt );
 
     std::size_t n_agents() const
     {
-        return adjacency_list.size();
+        return neighbour_list.size();
     }
 
     // Seed only once
@@ -30,15 +26,16 @@ public:
     }
 
     void get_adjacencies( std::size_t agent_idx, std::vector<size_t> & buffer ) const;
-    void get_edges( std::size_t agent_idx, connectionVectorT & buffer ) const;
+    void get_weights( std::size_t agent_idx, std::vector<double> & buffer ) const;
 
 private:
-    std::vector<connectionVectorT> adjacency_list; // Adjacency list for the connections
+    std::vector<std::vector<size_t>> neighbour_list; // Neighbour list for the connections
+    std::vector<std::vector<double>> weight_list;    // List for the interaction weights of each connection
     std::mt19937 gen;
 
     // Function for getting a vector of k agents (corresponding to connections)
     // drawing from n agents (without duplication)
-    // also includes agent_idx, the agent itself
+    // We later add the agent itself
     void draw_unique_k_from_n( std::size_t agent_idx, std::size_t k, std::size_t n, std::vector<std::size_t> & buffer );
 };
 

--- a/include/util/io.hpp
+++ b/include/util/io.hpp
@@ -48,8 +48,6 @@ void simulation_state_to_file( Simulation & simulation, std::string file_path )
     auto & model    = simulation.model;
     size_t n_agents = network.n_agents();
 
-    auto buffer = Network::connectionVectorT();
-
     for( size_t idx_agent = 0; idx_agent < n_agents; idx_agent++ )
     {
         std::string row = fmt::format( "{} {}\n", idx_agent, model->get_agent( idx_agent )->to_string() );

--- a/include/util/io.hpp
+++ b/include/util/io.hpp
@@ -24,7 +24,7 @@ void network_to_dot_file( const Network & network, std::string file_path )
 
     for( size_t idx_agent = 0; idx_agent < n_agents; idx_agent++ )
     {
-        network.get_adjacencies( idx_agent, buffer );
+        network.get_neighbours( idx_agent, buffer );
 
         std::string row = fmt::format( "{} -> {{", idx_agent );
         for( size_t i = 0; i < buffer.size() - 1; i++ )

--- a/src/models/DeGroot.cpp
+++ b/src/models/DeGroot.cpp
@@ -19,7 +19,7 @@ void Seldon::DeGrootModel::run()
 
     for( size_t i = 0; i < agents.size(); i++ )
     {
-        network.get_adjacencies( i, neighbour_buffer );
+        network.get_neighbours( i, neighbour_buffer );
         network.get_weights( i, weight_buffer );
         agents_current_copy[i].opinion = 0.0;
         for( size_t j = 0; j < neighbour_buffer.size(); j++ )

--- a/src/models/DeGroot.cpp
+++ b/src/models/DeGroot.cpp
@@ -12,18 +12,21 @@ Seldon::DeGrootModel::DeGrootModel( int n_agents, Network & network )
 
 void Seldon::DeGrootModel::run()
 {
-    auto edge_buffer = Network::connectionVectorT();
+    auto neighbour_buffer = std::vector<size_t>();
+    auto weight_buffer    = std::vector<double>();
+    size_t j_index;
+    double weight;
 
-    for( std::size_t i = 0; i < agents.size(); i++ )
+    for( size_t i = 0; i < agents.size(); i++ )
     {
-        network.get_edges( i, edge_buffer );
+        network.get_adjacencies( i, neighbour_buffer );
+        network.get_weights( i, weight_buffer );
         agents_current_copy[i].opinion = 0.0;
-        for( auto & edge : edge_buffer )
+        for( size_t j = 0; j < neighbour_buffer.size(); j++ )
         {
-            int j;
-            double weight;
-            std::tie( j, weight ) = edge;
-            agents_current_copy[i].opinion += weight * agents[j].opinion;
+            j_index = neighbour_buffer[j];
+            weight  = weight_buffer[j];
+            agents_current_copy[i].opinion += weight * agents[j_index].opinion;
         }
     }
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -108,7 +108,7 @@ void Seldon::Network::draw_unique_k_from_n(
     std::sample( SequenceGenerator( 0 ), SequenceGenerator( n ), buffer.begin(), k, gen );
 }
 
-void Seldon::Network::get_adjacencies( std::size_t agent_idx, std::vector<size_t> & buffer ) const
+void Seldon::Network::get_neighbours( std::size_t agent_idx, std::vector<size_t> & buffer ) const
 {
     // TODO: rewrite this using std::span
     const size_t n_edges = neighbour_list[agent_idx].size();

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -1,4 +1,6 @@
 #include "network.hpp"
+#include "connectivity.hpp"
+#include <fmt/format.h>
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
@@ -57,6 +59,18 @@ Seldon::Network::Network( size_t n_agents, size_t n_connections, std::optional<i
         weight_list.push_back( j_agent_weights );
 
     } // end of loop through n_agents
+
+    // Now that we have the neighbour list (or adjacency list)
+    // Run Tarjan's algorithm for strongly connected components
+    auto tarjan_scc = TarjanConnectivityAlgo( neighbour_list );
+
+    // For a strongly connected network, the number of SCCs should be 1
+    // Print a warning if this is not true
+    if( tarjan_scc.scc_list.size() != 1 )
+    {
+        fmt::print(
+            "WARNING: You have {} strongly connected components in your network!\n", tarjan_scc.scc_list.size() );
+    }
 }
 
 // Function for drawing k agents (indices), from n, without repitition


### PR DESCRIPTION
- Split the adjacency_list (which was a vector of vector of tuples) into two list of lists: the neighbour list, containing the neighbour indices of each agent (vector of vector of size_t), and the weight_list (vector of vector of doubles), containing the interaction weights for each pairwise interaction between agents i and j 
- Added an implementation of Tarjan's algorithm which determines whether the initialized network is strongly connected or not. Prints a warning if the network can be decomposed into more than 1 SCC (strongly connected component).
- Added a micromamba environment and install instructions in the README