### PR TITLE
ActivityDeiven model: Fixed bug in networks

### DIFF
--- a/src/models/ActivityDrivenModel.cpp
+++ b/src/models/ActivityDrivenModel.cpp
@@ -47,7 +47,7 @@ void Seldon::ActivityAgentModel::get_agents_from_power_law()
 
 void Seldon::ActivityAgentModel::update_network_probabilistic()
 {
-    network = Network( {}, {}, Network::EdgeDirection::Outgoing );
+    network.switch_direction_flag();
 
     std::uniform_real_distribution<> dis_activation( 0.0, 1.0 );
     std::uniform_real_distribution<> dis_reciprocation( 0.0, 1.0 );


### PR DESCRIPTION
The network was overwritten with an empty network all the time, so nothing was being calculated.