### PR TITLE
Added benchmarking support with benchmark_activity.cpp and benchmark_deGroot.cpp

### DIFF
--- a/benchmark/benchmark_activity.cpp
+++ b/benchmark/benchmark_activity.cpp
@@ -1,0 +1,135 @@
+#include "config_parser.hpp"
+#include "models/DeGroot.hpp"
+#include "simulation.hpp"
+#include <benchmark/benchmark.h>
+#include <argparse/argparse.hpp>
+#include <filesystem>
+#include <memory>
+#include <models/ActivityDrivenModel.hpp>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace Seldon;
+using AgentT = ActivityDrivenModel::AgentT;
+
+// Benchmark function for ActivityDriven model simulation
+static void BM_ActivityDriven( benchmark::State & state )
+{
+
+    auto proj_root_path = fs::current_path();
+    auto input_file = proj_root_path / fs::path( "test/res/activity_probabilistic_conf.toml" );
+
+    auto options = Config::parse_config_file( input_file.string() );
+    auto simulation = Simulation<AgentT>( options, std::nullopt, std::nullopt );
+
+    fs::path output_dir_path = proj_root_path / fs::path( "test/output" );
+        fs::create_directories( output_dir_path );
+
+    for (auto _ : state) {
+        fs::remove_all(output_dir_path);
+        fs::create_directories(output_dir_path);
+
+        assert(fs::is_empty(output_dir_path));
+
+        simulation.run(output_dir_path);
+
+        assert(!fs::is_empty(output_dir_path));
+
+        // Cleanup
+        fs::remove_all(output_dir_path);
+    }
+}
+
+// Benchmark function for ActivityDriven model simulation with two agents
+static void BM_ActivityDriven_withTwoAgents(benchmark::State& state) {
+
+
+    auto proj_root_path = std::filesystem::current_path();
+    auto input_file = proj_root_path / std::filesystem::path("test/res/2_agents_activity_prob.toml");
+
+    auto options = Config::parse_config_file(input_file.string());
+    auto simulation = Simulation<AgentT>(options, std::nullopt, std::nullopt);
+
+    fs::path output_dir_path = proj_root_path / std::filesystem::path("test/output");
+
+    for (auto _ : state) {
+        simulation.run(output_dir_path);
+
+        auto model_settings = std::get<Seldon::Config::ActivityDrivenSettings>(options.model_settings);
+        auto K = model_settings.K;
+        auto alpha = model_settings.alpha;
+
+        assert(std::abs(K - 2.0) < 1e-16);
+        assert(std::abs(alpha - 1.01) < 1e-16);
+
+        double analytical_x = 1.9187384098662013;
+
+         for (size_t idx_agent = 0; idx_agent < simulation.network.n_agents(); idx_agent++) {
+            auto &agent = simulation.network.agents[idx_agent];
+            assert(std::abs(agent.data.opinion - analytical_x) < 1e-4);
+        }
+
+        // Cleanup
+        fs::remove_all(output_dir_path);
+    }
+}
+
+
+// Benchmark function for ActivityDriven model simulation with one bot and one agent
+static void BM_ActivityDriven_withOneBotOneAgent(benchmark::State& state) {
+
+    auto proj_root_path = std::filesystem::current_path();
+    auto input_file = proj_root_path / std::filesystem::path("test/res/1bot_1agent_activity_prob.toml");
+
+    auto options = Config::parse_config_file(input_file.string());
+    Config::print_settings(options);
+
+    auto simulation = Simulation<AgentT>(options, std::nullopt, std::nullopt);
+
+    fs::path output_dir_path = proj_root_path / std::filesystem::path("test/output");
+
+    for (auto _ : state) {
+        // Get the bot opinion (which won't change)
+        auto bot = simulation.network.agents[0];
+        auto x_bot = bot.data.opinion; // Bot opinion
+
+        // Get the initial agent opinion
+        auto &agent = simulation.network.agents[1];
+        auto x_0 = agent.data.opinion; // Agent opinion
+
+        simulation.run(output_dir_path);
+
+        auto model_settings = std::get<Seldon::Config::ActivityDrivenSettings>(options.model_settings);
+        auto K = model_settings.K;
+        auto alpha = model_settings.alpha;
+        auto iterations = model_settings.max_iterations.value();
+        auto dt = model_settings.dt;
+        auto time_elapsed = iterations * dt;
+
+        // Final agent and bot opinions after the simulation run
+        auto x_t = agent.data.opinion;
+        auto x_t_bot = bot.data.opinion;
+        auto reluctance = agent.data.reluctance;
+        // The bot opinion should not change during the simulation
+        assert(std::abs(x_t_bot - x_bot) < 1e-16);
+
+        auto x_t_analytical = (x_0 - K / reluctance * tanh(alpha * x_bot)) * exp(-time_elapsed)
+                              + K / reluctance * tanh(alpha * x_bot);
+
+        assert(std::abs(x_t - x_t_analytical) < 1e-5);
+
+        // Cleanup
+        fs::remove_all(output_dir_path);
+    }
+}
+
+
+
+
+// Register the benchmark
+BENCHMARK( BM_ActivityDriven );
+BENCHMARK( BM_ActivityDriven_withTwoAgents );
+BENCHMARK( BM_ActivityDriven_withOneBotOneAgent );
+
+// Run the main
+BENCHMARK_MAIN();

--- a/benchmark/benchmark_deGroot.cpp
+++ b/benchmark/benchmark_deGroot.cpp
@@ -20,11 +20,14 @@ static void BM_DeGroot_Model(benchmark::State& state) {
         {0.2, 0.8},
     };
 
+    auto settings = Config::DeGrootSettings(); 
     auto network = Network(std::move(neighbour_list), std::move(weight_list), Network::EdgeDirection::Incoming);
-    auto model = DeGrootModel(network);
 
-    model.convergence_tol = 1e-6;
-    model.max_iterations = 100;
+    settings.convergence_tol = 1e-6;
+    settings.max_iterations  = 100;    
+
+    auto model = DeGrootModel(settings,network);
+
     network.agents[0].data.opinion = 0.0;
     network.agents[1].data.opinion = 1.0;
 

--- a/benchmark/benchmark_deGroot.cpp
+++ b/benchmark/benchmark_deGroot.cpp
@@ -1,0 +1,43 @@
+#include <benchmark/benchmark.h>
+#include "config_parser.hpp"
+#include "models/DeGroot.hpp"
+#include "network.hpp"
+#include <random>
+
+using namespace Seldon;
+
+// Benchmark function for deGroot model simulation
+static void BM_DeGroot_Model(benchmark::State& state) {
+    using Network = Network<DeGrootModel::AgentT>;
+    size_t n_agents = 2;
+    auto neighbour_list = std::vector<std::vector<size_t>>{
+        {1, 0},
+        {0, 1},
+    };
+
+    auto weight_list = std::vector<std::vector<double>>{
+        {0.2, 0.8},
+        {0.2, 0.8},
+    };
+
+    auto network = Network(std::move(neighbour_list), std::move(weight_list), Network::EdgeDirection::Incoming);
+    auto model = DeGrootModel(network);
+
+    model.convergence_tol = 1e-6;
+    model.max_iterations = 100;
+    network.agents[0].data.opinion = 0.0;
+    network.agents[1].data.opinion = 1.0;
+
+    for (auto _ : state) {
+        while (!model.finished()) {
+            model.iteration();
+        }
+    }
+
+}
+
+// Register the benchmark
+BENCHMARK(BM_DeGroot_Model);
+
+// Run the benchmark
+BENCHMARK_MAIN();

--- a/environment.yml
+++ b/environment.yml
@@ -19,3 +19,4 @@ dependencies:
   - clang-format
   - tomlplusplus
   - catch2
+  - benchmark

--- a/meson.build
+++ b/meson.build
@@ -39,3 +39,16 @@ foreach t : tests
   )
   test(t.get(0), exe, workdir : meson.project_source_root())
 endforeach
+
+benchmarks = [
+  ['Benchmark_ActivityDriven_Model','benchmark/benchmark_activity.cpp'],
+  ['Benchmark_deGroot_Model','benchmark/benchmark_deGroot.cpp'],
+]
+
+foreach b : benchmarks
+  exe = executable(b.get(0), sources_seldon + b.get(1),
+    dependencies : [dependency('fmt'), dependency('tomlplusplus'),Catch2,dependency('benchmark')],
+    include_directories : incdir
+  )
+  benchmark(b.get(0), exe, workdir : meson.project_source_root())
+endforeach


### PR DESCRIPTION
Hi @HaoZeke, thank you for the comments. As you mentioned yesterday, I discovered that there is an option for benchmarking in Meson. It's meson test --benchmark. I created a separate folder named "benchmark" and added yesterday's changes. Initially, it seemed to time out. However, I reverted to using hardcoded paths and it worked. Then, I realized that if I want to benchmark a function, it should be just a function regardless of the paths. After reviewing the test programs, I noticed that there were custom paths to specific files. Therefore, I attempted to benchmark the models provided in the test folder, which succeeded.If this approach suits the needs, I can proceed with benchmarking the remaining files located in the test folder.

Thank you once more. I am eagerly anticipating your continued assistance and guidance.