### PR TITLE
Simulation constructor refactor

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,6 @@ dependencies:
   - cmake
   - ninja 
   - cpp-argparse
-  - clang-format
+  - clang-format=18.1.1
   - tomlplusplus
   - catch2

--- a/examples/Deffuant/conf.toml
+++ b/examples/Deffuant/conf.toml
@@ -1,0 +1,21 @@
+[simulation]
+model = "Deffuant"
+# rng_seed = 120 # Leaving this empty will pick a random seed
+
+[io]
+# n_output_network = 20 # Write the network every 20 iterations
+n_output_agents = 1 # Write the opinions of agents after every iteration
+print_progress = true # Print the iteration time ; if not set, then does not prints
+output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+
+[model]
+max_iterations = 1000 # If not set, max iterations is infinite
+
+[Deffuant]
+homophily_threshold = 0.2 # d in the paper; agents interact if difference in opinion is less than this value 
+mu = 0.5 # convergence parameter; similar to social interaction strength K (0,0.5] 
+
+[network]
+number_of_agents = 1000
+connections_per_agent = 0

--- a/examples/Deffuant/conf.toml
+++ b/examples/Deffuant/conf.toml
@@ -15,6 +15,7 @@ max_iterations = 1000 # If not set, max iterations is infinite
 [Deffuant]
 homophily_threshold = 0.2 # d in the paper; agents interact if difference in opinion is less than this value 
 mu = 0.5 # convergence parameter; similar to social interaction strength K (0,0.5] 
+use_network = false # If true, will use a square lattice Will throw if sqrt(n_agents) is not an integer
 
 [network]
 number_of_agents = 1000

--- a/examples/DeffuantVector/conf.toml
+++ b/examples/DeffuantVector/conf.toml
@@ -1,0 +1,24 @@
+[simulation]
+model = "Deffuant"
+# rng_seed = 120 # Leaving this empty will pick a random seed
+
+[io]
+# n_output_network = 20 # Write the network every 20 iterations
+n_output_agents = 1 # Write the opinions of agents after every iteration
+print_progress = true # Print the iteration time ; if not set, then does not prints
+output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+
+[model]
+max_iterations = 1000 # If not set, max iterations is infinite
+
+[Deffuant]
+homophily_threshold = 0.2 # d in the paper; agents interact if difference in opinion is less than this value 
+mu = 0.5 # convergence parameter; similar to social interaction strength K (0,0.5] 
+use_network = false # If true, will use a square lattice Will throw if sqrt(n_agents) is not an integer
+binary_vector = true # If true, this will be the multi-dimensional binary vector Deffuant model
+dim = 5 # For the multi-dimensional binary vector Deffuant model, define the number of dimensions in each opinion vector 
+
+[network]
+number_of_agents = 1000
+connections_per_agent = 0

--- a/include/agents/discrete_vector_agent.hpp
+++ b/include/agents/discrete_vector_agent.hpp
@@ -42,9 +42,8 @@ inline DiscreteVectorAgent agent_from_string<DiscreteVectorAgent>( const std::st
 {
     DiscreteVectorAgent res{};
 
-    auto callback = [&]( int idx_list [[maybe_unused]], const auto & substring ) {
-        res.data.opinion.push_back( std::stoi( substring ) );
-    };
+    auto callback = [&]( int idx_list [[maybe_unused]], const auto & substring )
+    { res.data.opinion.push_back( std::stoi( substring ) ); };
 
     parse_comma_separated_list( str, callback );
     return res;

--- a/include/agents/discrete_vector_agent.hpp
+++ b/include/agents/discrete_vector_agent.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "agent.hpp"
+#include "agent_io.hpp"
+#include "util/misc.hpp"
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace Seldon
+{
+
+struct DiscreteVectorAgentData
+{
+    std::vector<int> opinion{};
+};
+
+using DiscreteVectorAgent = Agent<DiscreteVectorAgentData>;
+
+template<>
+inline std::string agent_to_string<DiscreteVectorAgent>( const DiscreteVectorAgent & agent )
+{
+    if( agent.data.opinion.empty() )
+        return "";
+
+    auto res = fmt::format( "{}", agent.data.opinion[0] );
+    for( size_t i = 1; i < agent.data.opinion.size(); i++ )
+    {
+        res += fmt::format( ", {}", agent.data.opinion[i] );
+    }
+    return res;
+}
+
+template<>
+inline std::string opinion_to_string<DiscreteVectorAgent>( const DiscreteVectorAgent & agent )
+{
+    return agent_to_string( agent );
+}
+
+template<>
+inline DiscreteVectorAgent agent_from_string<DiscreteVectorAgent>( const std::string & str )
+{
+    DiscreteVectorAgent res{};
+
+    auto callback = [&]( int idx_list [[maybe_unused]], const auto & substring ) {
+        res.data.opinion.push_back( std::stoi( substring ) );
+    };
+
+    parse_comma_separated_list( str, callback );
+    return res;
+};
+
+// template<>
+// inline std::vector<std::string> agent_to_string_column_names<ActivityAgent>()
+// {
+//     return { "opinion", "activity", "reluctance" };
+// }
+
+} // namespace Seldon

--- a/include/config_parser.hpp
+++ b/include/config_parser.hpp
@@ -24,7 +24,8 @@ namespace Seldon::Config
 enum class Model
 {
     DeGroot,
-    ActivityDrivenModel
+    ActivityDrivenModel,
+    DeffuantModel
 };
 
 struct OutputSettings
@@ -41,6 +42,14 @@ struct DeGrootSettings
 {
     std::optional<int> max_iterations = std::nullopt;
     double convergence_tol;
+};
+
+struct DeffuantSettings
+{
+    std::optional<int> max_iterations = std::nullopt;
+    double homophily_threshold
+        = 0.2;       // d in the paper; agents interact if difference in opinion is less than this value
+    double mu = 0.5; // convergence parameter; similar to social interaction strength K (0,0.5]
 };
 
 struct ActivityDrivenSettings
@@ -81,7 +90,7 @@ struct SimulationOptions
     std::string model_string;
     int rng_seed = std::random_device()();
     OutputSettings output_settings;
-    std::variant<DeGrootSettings, ActivityDrivenSettings> model_settings;
+    std::variant<DeGrootSettings, ActivityDrivenSettings, DeffuantSettings> model_settings;
     InitialNetworkSettings network_settings;
 };
 

--- a/include/config_parser.hpp
+++ b/include/config_parser.hpp
@@ -48,8 +48,9 @@ struct DeffuantSettings
 {
     std::optional<int> max_iterations = std::nullopt;
     double homophily_threshold
-        = 0.2;       // d in the paper; agents interact if difference in opinion is less than this value
-    double mu = 0.5; // convergence parameter; similar to social interaction strength K (0,0.5]
+        = 0.2;              // d in the paper; agents interact if difference in opinion is less than this value
+    double mu        = 0.5; // convergence parameter; similar to social interaction strength K (0,0.5]
+    bool use_network = false;
 };
 
 struct ActivityDrivenSettings

--- a/include/config_parser.hpp
+++ b/include/config_parser.hpp
@@ -48,9 +48,12 @@ struct DeffuantSettings
 {
     std::optional<int> max_iterations = std::nullopt;
     double homophily_threshold
-        = 0.2;              // d in the paper; agents interact if difference in opinion is less than this value
-    double mu        = 0.5; // convergence parameter; similar to social interaction strength K (0,0.5]
-    bool use_network = false;
+        = 0.2;                      // d in the paper; agents interact if difference in opinion is less than this value
+    double mu              = 0.5;   // convergence parameter; similar to social interaction strength K (0,0.5]
+    bool use_network       = false; // For using a square lattice network
+    bool use_binary_vector = false; // For the multi-dimensional DeffuantModelVector; by default set to false
+    size_t dim
+        = 1; // The size of the opinions vector. This is used for the multi-dimensional DeffuantModelVector model.
 };
 
 struct ActivityDrivenSettings

--- a/include/config_parser.hpp
+++ b/include/config_parser.hpp
@@ -87,11 +87,12 @@ struct InitialNetworkSettings
 
 struct SimulationOptions
 {
+    using ModelVariantT = std::variant<DeGrootSettings, ActivityDrivenSettings, DeffuantSettings>;
     Model model;
     std::string model_string;
     int rng_seed = std::random_device()();
     OutputSettings output_settings;
-    std::variant<DeGrootSettings, ActivityDrivenSettings, DeffuantSettings> model_settings;
+    ModelVariantT model_settings;
     InitialNetworkSettings network_settings;
 };
 

--- a/include/connectivity.hpp
+++ b/include/connectivity.hpp
@@ -75,7 +75,7 @@ private:
                 {
                     lowest[v] = std::min( lowest[v], num[u] );
                 } // u not processed
-            } // u has been visited
+            }     // u has been visited
         }
 
         // Now v has been processed

--- a/include/connectivity.hpp
+++ b/include/connectivity.hpp
@@ -75,7 +75,7 @@ private:
                 {
                     lowest[v] = std::min( lowest[v], num[u] );
                 } // u not processed
-            }     // u has been visited
+            } // u has been visited
         }
 
         // Now v has been processed

--- a/include/model.hpp
+++ b/include/model.hpp
@@ -15,6 +15,9 @@ public:
 
     std::optional<size_t> max_iterations = std::nullopt;
 
+    Model() = default;
+    Model( std::optional<size_t> max_iterations ) : max_iterations( max_iterations ){};
+
     virtual void initialize_iterations()
     {
         _n_iterations = 0;

--- a/include/model.hpp
+++ b/include/model.hpp
@@ -13,8 +13,6 @@ class Model
 public:
     using AgentT = AgentT_;
 
-    std::optional<size_t> max_iterations = std::nullopt;
-
     Model() = default;
     Model( std::optional<size_t> max_iterations ) : max_iterations( max_iterations ){};
 
@@ -48,6 +46,7 @@ public:
     virtual ~Model() = default;
 
 private:
+    std::optional<size_t> max_iterations = std::nullopt;
     size_t _n_iterations{};
 };
 

--- a/include/model_factory.hpp
+++ b/include/model_factory.hpp
@@ -1,0 +1,80 @@
+#include "config_parser.hpp"
+#include "model.hpp"
+#include "models/ActivityDrivenModel.hpp"
+#include "models/DeGroot.hpp"
+#include "models/DeffuantModel.hpp"
+#include "network.hpp"
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <type_traits>
+
+namespace Seldon::ModelFactory
+{
+
+using ModelVariantT = Config::SimulationOptions::ModelVariantT;
+
+template<typename AgentT, typename ModelT, typename FuncT>
+auto check_agent_type( FuncT func )
+{
+    if constexpr( std::is_same_v<AgentT, typename ModelT::AgentT> )
+    {
+        return func();
+    }
+    else
+    {
+        throw std::runtime_error( "Incompatible agent and model type!" );
+        return std::unique_ptr<Model<AgentT>>{};
+    }
+}
+
+template<typename AgentT>
+inline auto create_model_degroot( Network<AgentT> & network, const ModelVariantT & model_settings )
+{
+    if constexpr( std::is_same_v<AgentT, DeGrootModel::AgentT> )
+    {
+        auto degroot_settings = std::get<Config::DeGrootSettings>( model_settings );
+        auto model            = std::make_unique<DeGrootModel>( degroot_settings, network );
+        return model;
+    }
+    else
+    {
+        throw std::runtime_error( "Incompatible agent and model type!" );
+        return std::unique_ptr<Model<AgentT>>{};
+    }
+}
+
+template<typename AgentT>
+inline auto
+create_model_activity_driven( Network<AgentT> & network, const ModelVariantT & model_settings, std::mt19937 & gen )
+{
+    if constexpr( std::is_same_v<AgentT, ActivityDrivenModel::AgentT> )
+    {
+        auto activitydriven_settings = std::get<Config::ActivityDrivenSettings>( model_settings );
+        auto model                   = std::make_unique<ActivityDrivenModel>( activitydriven_settings, network, gen );
+        return model;
+    }
+    else
+    {
+        throw std::runtime_error( "Incompatible agent and model type!" );
+        return std::unique_ptr<Model<AgentT>>{};
+    }
+}
+
+template<typename AgentT>
+inline auto create_model_deffuant( Network<AgentT> & network, const ModelVariantT & model_settings, std::mt19937 & gen )
+{
+    if constexpr( std::is_same_v<AgentT, DeffuantModel::AgentT> )
+    {
+        auto deffuant_settings = std::get<Config::DeffuantSettings>( model_settings );
+        auto model             = std::make_unique<DeffuantModel>( deffuant_settings, network, gen );
+        return model;
+    }
+    else
+    {
+        throw std::runtime_error( "Incompatible agent and model type!" );
+        return std::unique_ptr<Model<AgentT>>{};
+    }
+}
+
+} // namespace Seldon::ModelFactory

--- a/include/model_factory.hpp
+++ b/include/model_factory.hpp
@@ -77,4 +77,22 @@ inline auto create_model_deffuant( Network<AgentT> & network, const ModelVariant
     }
 }
 
+template<typename AgentT>
+inline auto
+create_model_deffuant_vector( Network<AgentT> & network, const ModelVariantT & model_settings, std::mt19937 & gen )
+{
+    if constexpr( std::is_same_v<AgentT, DeffuantModelVector::AgentT> )
+    {
+        auto deffuant_settings = std::get<Config::DeffuantSettings>( model_settings );
+        auto model             = std::make_unique<DeffuantModelVector>( deffuant_settings, network, gen );
+        model.initialize_agents();
+        return model;
+    }
+    else
+    {
+        throw std::runtime_error( "Incompatible agent and model type!" );
+        return std::unique_ptr<Model<AgentT>>{};
+    }
+}
+
 } // namespace Seldon::ModelFactory

--- a/include/model_factory.hpp
+++ b/include/model_factory.hpp
@@ -68,6 +68,7 @@ inline auto create_model_deffuant( Network<AgentT> & network, const ModelVariant
     {
         auto deffuant_settings = std::get<Config::DeffuantSettings>( model_settings );
         auto model             = std::make_unique<DeffuantModel>( deffuant_settings, network, gen );
+        model->initialize_agents( deffuant_settings.dim );
         return model;
     }
     else
@@ -85,7 +86,7 @@ create_model_deffuant_vector( Network<AgentT> & network, const ModelVariantT & m
     {
         auto deffuant_settings = std::get<Config::DeffuantSettings>( model_settings );
         auto model             = std::make_unique<DeffuantModelVector>( deffuant_settings, network, gen );
-        model.initialize_agents();
+        model->initialize_agents( deffuant_settings.dim );
         return model;
     }
     else

--- a/include/models/ActivityDrivenModel.hpp
+++ b/include/models/ActivityDrivenModel.hpp
@@ -67,26 +67,26 @@ public:
     // Model-specific parameters
     double dt = 0.01; // Timestep for the integration of the coupled ODEs
     // Various free parameters
-    int m            = 10;   // Number of agents contacted, when the agent is active
-    double eps       = 0.01; // Minimum activity epsilon; a_i belongs to [epsilon,1]
-    double gamma     = 2.1;  // Exponent of activity power law distribution of activities
-    double alpha     = 3.0;  // Controversialness of the issue, must be greater than 0.
-    double homophily = 0.5;  // aka beta. if zero, agents pick their interaction partners at random
+    int m{};            // Number of agents contacted, when the agent is active
+    double eps{};       // Minimum activity epsilon; a_i belongs to [epsilon,1]
+    double gamma{};     // Exponent of activity power law distribution of activities
+    double alpha{};     // Controversialness of the issue, must be greater than 0.
+    double homophily{}; // aka beta. if zero, agents pick their interaction partners at random
     // Reciprocity aka r. probability that when agent i contacts j via weighted reservoir sampling
     // j also sends feedback to i. So every agent can have more than m incoming connections
-    double reciprocity = 0.5;
-    double K           = 3.0; // Social interaction strength; K>0
+    double reciprocity{};
+    double K{}; // Social interaction strength; K>0
 
     bool mean_activities = false;
     bool mean_weights    = false;
 
     double convergence_tol = 1e-12; // TODO: ??
 
-    bool use_reluctances     = false;
-    double reluctance_mean   = 1.0;
-    double reluctance_sigma  = 0.25;
-    double reluctance_eps    = 0.01;
-    double covariance_factor = 0.0;
+    bool use_reluctances = false;
+    double reluctance_mean{};
+    double reluctance_sigma{};
+    double reluctance_eps{};
+    double covariance_factor{};
 
     // bot @TODO: less hacky
 

--- a/include/models/ActivityDrivenModel.hpp
+++ b/include/models/ActivityDrivenModel.hpp
@@ -33,7 +33,7 @@ private:
     std::set<std::pair<size_t, size_t>> reciprocal_edge_buffer{};
 
     // Model-specific parameters
-    double dt = 0.01; // Timestep for the integration of the coupled ODEs
+    double dt{}; // Timestep for the integration of the coupled ODEs
     // Various free parameters
     int m{};            // Number of agents contacted, when the agent is active
     double eps{};       // Minimum activity epsilon; a_i belongs to [epsilon,1]

--- a/include/models/ActivityDrivenModel.hpp
+++ b/include/models/ActivityDrivenModel.hpp
@@ -19,6 +19,48 @@ public:
     using AgentT   = ActivityAgent;
     using NetworkT = Network<AgentT>;
 
+    ActivityDrivenModel( NetworkT & network, std::mt19937 & gen );
+
+    void get_agents_from_power_law(); // This needs to be called after eps and gamma have been set
+
+    void iteration() override;
+
+    // Model-specific parameters
+    double dt = 0.01; // Timestep for the integration of the coupled ODEs
+    // Various free parameters
+    int m{};            // Number of agents contacted, when the agent is active
+    double eps{};       // Minimum activity epsilon; a_i belongs to [epsilon,1]
+    double gamma{};     // Exponent of activity power law distribution of activities
+    double alpha{};     // Controversialness of the issue, must be greater than 0.
+    double homophily{}; // aka beta. if zero, agents pick their interaction partners at random
+    // Reciprocity aka r. probability that when agent i contacts j via weighted reservoir sampling
+    // j also sends feedback to i. So every agent can have more than m incoming connections
+    double reciprocity{};
+    double K{}; // Social interaction strength; K>0
+
+    bool mean_activities = false;
+    bool mean_weights    = false;
+
+    double convergence_tol = 1e-12; // TODO: ??
+
+    bool use_reluctances = false;
+    double reluctance_mean{};
+    double reluctance_sigma{};
+    double reluctance_eps{};
+    double covariance_factor{};
+
+    // bot @TODO: less hacky
+    size_t n_bots                     = 0; // The first n_bots agents are bots
+    std::vector<int> bot_m            = std::vector<int>( 0 );
+    std::vector<double> bot_activity  = std::vector<double>( 0 );
+    std::vector<double> bot_opinion   = std::vector<double>( 0 );
+    std::vector<double> bot_homophily = std::vector<double>( 0 );
+
+    [[nodiscard]] bool bot_present() const
+    {
+        return n_bots > 0;
+    }
+
 private:
     NetworkT & network;
     std::vector<std::vector<NetworkT::WeightT>> contact_prob_list; // Probability of choosing i in 1 to m rounds
@@ -62,50 +104,6 @@ private:
     void update_network_probabilistic();
     void update_network_mean();
     void update_network();
-
-public:
-    // Model-specific parameters
-    double dt = 0.01; // Timestep for the integration of the coupled ODEs
-    // Various free parameters
-    int m{};            // Number of agents contacted, when the agent is active
-    double eps{};       // Minimum activity epsilon; a_i belongs to [epsilon,1]
-    double gamma{};     // Exponent of activity power law distribution of activities
-    double alpha{};     // Controversialness of the issue, must be greater than 0.
-    double homophily{}; // aka beta. if zero, agents pick their interaction partners at random
-    // Reciprocity aka r. probability that when agent i contacts j via weighted reservoir sampling
-    // j also sends feedback to i. So every agent can have more than m incoming connections
-    double reciprocity{};
-    double K{}; // Social interaction strength; K>0
-
-    bool mean_activities = false;
-    bool mean_weights    = false;
-
-    double convergence_tol = 1e-12; // TODO: ??
-
-    bool use_reluctances = false;
-    double reluctance_mean{};
-    double reluctance_sigma{};
-    double reluctance_eps{};
-    double covariance_factor{};
-
-    // bot @TODO: less hacky
-
-    size_t n_bots                     = 0; // The first n_bots agents are bots
-    std::vector<int> bot_m            = std::vector<int>( 0 );
-    std::vector<double> bot_activity  = std::vector<double>( 0 );
-    std::vector<double> bot_opinion   = std::vector<double>( 0 );
-    std::vector<double> bot_homophily = std::vector<double>( 0 );
-
-    [[nodiscard]] bool bot_present() const
-    {
-        return n_bots > 0;
-    }
-
-    ActivityDrivenModel( NetworkT & network, std::mt19937 & gen );
-
-    void get_agents_from_power_law(); // This needs to be called after eps and gamma have been set
-
-    void iteration() override;
 };
 
 } // namespace Seldon

--- a/include/models/DeGroot.hpp
+++ b/include/models/DeGroot.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "agents/simple_agent.hpp"
+#include "config_parser.hpp"
 #include "model.hpp"
 #include "network.hpp"
 #include <optional>
@@ -11,16 +12,16 @@ namespace Seldon
 class DeGrootModel : public Model<SimpleAgent>
 {
 public:
-    using AgentT           = SimpleAgent;
-    using NetworkT         = Network<AgentT>;
-    double convergence_tol = 1e-12;
+    using AgentT   = SimpleAgent;
+    using NetworkT = Network<AgentT>;
 
-    DeGrootModel( NetworkT & network );
+    DeGrootModel( Config::DeGrootSettings settings, NetworkT & network );
 
     void iteration() override;
     bool finished() override;
 
 private:
+    double convergence_tol{};
     std::optional<double> max_opinion_diff = std::nullopt;
     NetworkT & network;
     std::vector<AgentT> agents_current_copy;

--- a/include/models/DeffuantModel.hpp
+++ b/include/models/DeffuantModel.hpp
@@ -2,6 +2,7 @@
 
 #include "agents/discrete_vector_agent.hpp"
 #include "agents/simple_agent.hpp"
+#include "config_parser.hpp"
 #include "model.hpp"
 #include "network.hpp"
 #include "util/math.hpp"
@@ -9,9 +10,6 @@
 #include <random>
 
 #include "network_generation.hpp"
-#include <set>
-#include <string>
-#include <utility>
 
 #include <vector>
 
@@ -25,12 +23,14 @@ public:
     using AgentT   = AgentT_;
     using NetworkT = Network<AgentT>;
 
-    double homophily_threshold = 0.2;   // d in paper
-    double mu                  = 0.5;   // convergence parameter
-    bool use_network           = false; // for the basic Deffuant model
-
-    DeffuantModelAbstract( NetworkT & network, std::mt19937 & gen, bool use_network )
-            : Model<AgentT>(), use_network( use_network ), network( network ), gen( gen )
+    DeffuantModelAbstract(
+        const Config::DeffuantSettings & settings, NetworkT & network, std::mt19937 & gen, bool use_network )
+            : Model<AgentT>( settings.max_iterations ),
+              homophily_threshold( settings.homophily_threshold ),
+              mu( settings.mu ),
+              use_network( settings.use_network ),
+              network( network ),
+              gen( gen )
     {
         // Generate the network as a square lattice if use_network is true
         if( use_network )
@@ -103,6 +103,9 @@ public:
     // bool finished() override;
 
 private:
+    double homophily_threshold{}; // d in paper
+    double mu{};                  // convergence parameter
+    bool use_network{};           // for the basic Deffuant model
     NetworkT & network;
     std::mt19937 & gen; // reference to simulation Mersenne-Twister engine
 };

--- a/include/models/DeffuantModel.hpp
+++ b/include/models/DeffuantModel.hpp
@@ -1,39 +1,113 @@
 #pragma once
 
+#include "agents/discrete_vector_agent.hpp"
 #include "agents/simple_agent.hpp"
 #include "model.hpp"
 #include "network.hpp"
+#include "util/math.hpp"
 #include <cstddef>
 #include <random>
+
+#include "network_generation.hpp"
 #include <set>
 #include <string>
 #include <utility>
+
 #include <vector>
 
 namespace Seldon
 {
 
-class DeffuantModel : public Model<SimpleAgent>
+template<typename AgentT_>
+class DeffuantModelAbstract : public Model<AgentT_>
 {
 public:
-    using AgentT   = SimpleAgent;
+    using AgentT   = AgentT_;
     using NetworkT = Network<AgentT>;
 
     double homophily_threshold = 0.2;   // d in paper
     double mu                  = 0.5;   // convergence parameter
     bool use_network           = false; // for the basic Deffuant model
 
-    DeffuantModel( NetworkT & network, std::mt19937 & gen, bool use_network );
+    DeffuantModelAbstract( NetworkT & network, std::mt19937 & gen, bool use_network )
+            : Model<AgentT>(), use_network( use_network ), network( network ), gen( gen )
+    {
+        // Generate the network as a square lattice if use_network is true
+        if( use_network )
+        {
+            size_t n_edge = std::sqrt( network.n_agents() );
+            if( n_edge * n_edge != network.n_agents() )
+            {
+                throw std::runtime_error( "Number of agents is not a square number." );
+            }
+            network = NetworkGeneration::generate_square_lattice<AgentT>( n_edge );
+        }
+        initialize_agents();
+    }
 
-    void iteration() override;
+    std::vector<std::size_t> select_interacting_agent_pair()
+    {
+        auto interacting_agents = std::vector<std::size_t>();
+        // If the basic model is being used, then search from all possible agents
+        if( !use_network )
+        {
+
+            // Pick any two agents to interact, randomly, without repetition
+            draw_unique_k_from_n( std::nullopt, 2, network.n_agents(), interacting_agents, gen );
+
+            return interacting_agents;
+        }
+        else
+        {
+            // First select an agent randomly
+            auto dist       = std::uniform_int_distribution<size_t>( 0, network.n_agents() - 1 );
+            auto agent1_idx = dist( gen );
+            interacting_agents.push_back( agent1_idx );
+
+            // Choose a neighbour randomly from the neighbour list of agent1_idx
+            auto neighbours     = network.get_neighbours( agent1_idx );
+            auto n_neighbours   = neighbours.size();
+            auto dist_n         = std::uniform_int_distribution<size_t>( 0, n_neighbours - 1 );
+            auto index_in_neigh = dist_n( gen ); // Index inside neighbours list
+            auto agent2_idx     = neighbours[index_in_neigh];
+            interacting_agents.push_back( agent2_idx );
+
+            return interacting_agents;
+        }
+    }
+
+    void iteration() override
+    {
+        Model<AgentT>::iteration(); // Update n_iterations
+
+        // Although the model defines each iteration as choosing *one*
+        // pair of agents, we will define each iteration as sampling
+        // n_agents pairs (similar to the time unit in evolution plots in the paper)
+        for( size_t i = 0; i < network.n_agents(); i++ )
+        {
+
+            auto interacting_agents = select_interacting_agent_pair();
+
+            auto & agent1 = network.agents[interacting_agents[0]];
+            auto & agent2 = network.agents[interacting_agents[1]];
+
+            update_rule( agent1, agent2 );
+        }
+    }
+
+    // template<typename T>
+    void update_rule( AgentT & agent1, AgentT & agent2 );
+    void initialize_agents();
+
+    // void iteration() override;
     // bool finished() override;
 
 private:
     NetworkT & network;
     std::mt19937 & gen; // reference to simulation Mersenne-Twister engine
-
-    // Select interacting agents
-    std::vector<std::size_t> select_interacting_agent_pair();
 };
+
+using DeffuantModel       = DeffuantModelAbstract<SimpleAgent>;
+using DeffuantModelVector = DeffuantModelAbstract<DiscreteVectorAgent>;
 
 } // namespace Seldon

--- a/include/models/DeffuantModel.hpp
+++ b/include/models/DeffuantModel.hpp
@@ -41,8 +41,6 @@ public:
             }
             network = NetworkGeneration::generate_square_lattice<AgentT>( n_edge );
         }
-
-        initialize_agents();
     }
 
     std::vector<std::size_t> select_interacting_agent_pair()

--- a/include/models/DeffuantModel.hpp
+++ b/include/models/DeffuantModel.hpp
@@ -23,7 +23,7 @@ public:
     double mu                  = 0.5;   // convergence parameter
     bool use_network           = false; // for the basic Deffuant model
 
-    DeffuantModel( NetworkT & network, std::mt19937 & gen );
+    DeffuantModel( NetworkT & network, std::mt19937 & gen, bool use_network );
 
     void iteration() override;
     // bool finished() override;

--- a/include/models/DeffuantModel.hpp
+++ b/include/models/DeffuantModel.hpp
@@ -19,8 +19,9 @@ public:
     using AgentT   = SimpleAgent;
     using NetworkT = Network<AgentT>;
 
-    double homophily_threshold = 0.2; // d in paper
-    double mu                  = 0.5; // convergence parameter
+    double homophily_threshold = 0.2;   // d in paper
+    double mu                  = 0.5;   // convergence parameter
+    bool use_network           = false; // for the basic Deffuant model
 
     DeffuantModel( NetworkT & network, std::mt19937 & gen );
 
@@ -30,6 +31,9 @@ public:
 private:
     NetworkT & network;
     std::mt19937 & gen; // reference to simulation Mersenne-Twister engine
+
+    // Select interacting agents
+    std::vector<std::size_t> select_interacting_agent_pair();
 };
 
 } // namespace Seldon

--- a/include/models/DeffuantModel.hpp
+++ b/include/models/DeffuantModel.hpp
@@ -23,8 +23,7 @@ public:
     using AgentT   = AgentT_;
     using NetworkT = Network<AgentT>;
 
-    DeffuantModelAbstract(
-        const Config::DeffuantSettings & settings, NetworkT & network, std::mt19937 & gen, bool use_network )
+    DeffuantModelAbstract( const Config::DeffuantSettings & settings, NetworkT & network, std::mt19937 & gen )
             : Model<AgentT>( settings.max_iterations ),
               homophily_threshold( settings.homophily_threshold ),
               mu( settings.mu ),
@@ -42,6 +41,7 @@ public:
             }
             network = NetworkGeneration::generate_square_lattice<AgentT>( n_edge );
         }
+
         initialize_agents();
     }
 

--- a/include/models/DeffuantModel.hpp
+++ b/include/models/DeffuantModel.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "agents/simple_agent.hpp"
+#include "model.hpp"
+#include "network.hpp"
+#include <cstddef>
+#include <random>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Seldon
+{
+
+class DeffuantModel : public Model<SimpleAgent>
+{
+public:
+    using AgentT   = SimpleAgent;
+    using NetworkT = Network<AgentT>;
+
+    double homophily_threshold = 0.2; // d in paper
+    double mu                  = 0.5; // convergence parameter
+
+    DeffuantModel( NetworkT & network, std::mt19937 & gen );
+
+    void iteration() override;
+    // bool finished() override;
+
+private:
+    NetworkT & network;
+    std::mt19937 & gen; // reference to simulation Mersenne-Twister engine
+};
+
+} // namespace Seldon

--- a/include/models/DeffuantModel.hpp
+++ b/include/models/DeffuantModel.hpp
@@ -95,7 +95,7 @@ public:
 
     // template<typename T>
     void update_rule( AgentT & agent1, AgentT & agent2 );
-    void initialize_agents();
+    void initialize_agents( size_t dim [[maybe_unused]] );
 
     // void iteration() override;
     // bool finished() override;

--- a/include/network.hpp
+++ b/include/network.hpp
@@ -228,6 +228,66 @@ public:
         }
     }
 
+    /*
+    Sorts the neighbours by index and removes doubly counted edges by summing the weights
+    */
+    void remove_double_counting()
+    {
+        std::vector<size_t> sorting_indices{};
+
+        for( size_t idx_agent = 0; idx_agent < n_agents(); idx_agent++ )
+        {
+
+            auto & neighbours = neighbour_list[idx_agent];
+            auto & weights    = weight_list[idx_agent];
+
+            std::vector<WeightT> weights_copy{};
+            std::vector<size_t> neighbours_copy{};
+
+            const auto n_neighbours = neighbours.size();
+
+            // First we will the sorting_indices array
+            sorting_indices.resize( n_neighbours );
+            std::iota( sorting_indices.begin(), sorting_indices.end(), 0 );
+
+            // Then, we figure out how to sort the neighbour indices list
+            std::sort( sorting_indices.begin(), sorting_indices.end(), [&]( auto i1, auto i2 ) {
+                return neighbours[i1] < neighbours[i2];
+            } );
+
+            std::optional<size_t> last_neighbour_index = std::nullopt;
+            for( size_t i = 0; i < n_neighbours; i++ )
+            {
+                const auto sort_idx              = sorting_indices[i];
+                const auto current_neigbhour_idx = neighbours[sort_idx];
+                const auto current_weight        = weights[sort_idx];
+
+                if( last_neighbour_index != current_neigbhour_idx )
+                {
+                    weights_copy.push_back( current_weight );
+                    neighbours_copy.push_back( current_neigbhour_idx );
+                    last_neighbour_index = current_neigbhour_idx;
+                }
+                else
+                {
+                    weights_copy.back() += current_weight;
+                }
+            }
+
+            weight_list[idx_agent]    = weights_copy;
+            neighbour_list[idx_agent] = neighbours_copy;
+        }
+    }
+
+    /*
+    Clears the network
+    */
+    void clear()
+    {
+        neighbour_list.clear();
+        weight_list.clear();
+    }
+
 private:
     std::vector<std::vector<size_t>> neighbour_list; // Neighbour list for the connections
     std::vector<std::vector<WeightT>> weight_list;   // List for the interaction weights of each connection

--- a/include/network.hpp
+++ b/include/network.hpp
@@ -258,9 +258,9 @@ public:
             std::iota( sorting_indices.begin(), sorting_indices.end(), 0 );
 
             // Then, we figure out how to sort the neighbour indices list
-            std::sort( sorting_indices.begin(), sorting_indices.end(), [&]( auto i1, auto i2 ) {
-                return neighbours[i1] < neighbours[i2];
-            } );
+            std::sort(
+                sorting_indices.begin(), sorting_indices.end(),
+                [&]( auto i1, auto i2 ) { return neighbours[i1] < neighbours[i2]; } );
 
             std::optional<size_t> last_neighbour_index = std::nullopt;
             for( size_t i = 0; i < n_neighbours; i++ )

--- a/include/network.hpp
+++ b/include/network.hpp
@@ -51,6 +51,13 @@ public:
     {
     }
 
+    Network( std::vector<AgentT> agents )
+            : agents( agents ),
+              neighbour_list( std::vector<std::vector<size_t>>( agents.size(), std::vector<size_t>{} ) ),
+              weight_list( std::vector<std::vector<WeightT>>( agents.size(), std::vector<WeightT>{} ) )
+    {
+    }
+
     Network(
         std::vector<std::vector<size_t>> && neighbour_list, std::vector<std::vector<WeightT>> && weight_list,
         EdgeDirection direction )

--- a/include/network.hpp
+++ b/include/network.hpp
@@ -44,6 +44,13 @@ public:
 
     Network() = default;
 
+    Network( size_t n_agents )
+            : agents( std::vector<AgentT>( n_agents ) ),
+              neighbour_list( std::vector<std::vector<size_t>>( n_agents, std::vector<size_t>{} ) ),
+              weight_list( std::vector<std::vector<WeightT>>( n_agents, std::vector<WeightT>{} ) )
+    {
+    }
+
     Network(
         std::vector<std::vector<size_t>> && neighbour_list, std::vector<std::vector<WeightT>> && weight_list,
         EdgeDirection direction )
@@ -59,7 +66,7 @@ public:
     */
     [[nodiscard]] std::size_t n_agents() const
     {
-        return neighbour_list.size();
+        return agents.size();
     }
 
     /*
@@ -284,14 +291,17 @@ public:
     */
     void clear()
     {
-        neighbour_list.clear();
-        weight_list.clear();
+        for( auto & w : weight_list )
+            w.clear();
+
+        for( auto & n : neighbour_list )
+            n.clear();
     }
 
 private:
-    std::vector<std::vector<size_t>> neighbour_list; // Neighbour list for the connections
-    std::vector<std::vector<WeightT>> weight_list;   // List for the interaction weights of each connection
-    EdgeDirection _direction;
+    std::vector<std::vector<size_t>> neighbour_list{}; // Neighbour list for the connections
+    std::vector<std::vector<WeightT>> weight_list{};   // List for the interaction weights of each connection
+    EdgeDirection _direction{};
 };
 
 } // namespace Seldon

--- a/include/network_generation.hpp
+++ b/include/network_generation.hpp
@@ -197,6 +197,7 @@ Network<AgentType> generate_from_file( const std::string & file )
         neighbour_list.emplace_back( 0 );
         weight_list.emplace_back( 0 );
 
+        //@TODO: refactor with util/parse_comma_separated_list
         size_t start_of_column = 0;
         bool finished_row      = false;
         size_t idx_column      = 0;
@@ -237,8 +238,7 @@ Network<AgentType> generate_from_file( const std::string & file )
     return NetworkT( std::move( neighbour_list ), std::move( weight_list ), NetworkT::EdgeDirection::Incoming );
 }
 
-/* Constructs a new network on a square lattice of edge length n_edge (with PBCs)
- */
+/* Constructs a new network on a square lattice of edge length n_edge (with PBCs)*/
 template<typename AgentType>
 Network<AgentType> generate_square_lattice( size_t n_edge, typename Network<AgentType>::WeightT weight = 0.0 )
 {

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -83,7 +83,6 @@ public:
 
         if constexpr( std::is_same_v<AgentType, DeGrootModel::AgentT> )
         {
-            fmt::print( "I am a simple agent\n" );
             if( options.model == Config::Model::DeGroot )
             {
                 auto degroot_settings = std::get<Config::DeGrootSettings>( options.model_settings );
@@ -104,7 +103,6 @@ public:
             }
             else if( options.model == Config::Model::DeffuantModel )
             {
-                fmt::print( "I am inside the Deffuant model loop.\n" );
                 auto deffuant_settings = std::get<Config::DeffuantSettings>( options.model_settings );
 
                 // Deffuant model specific parameters

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -70,9 +70,7 @@ public:
                 // DeGroot specific parameters
                 model = [&]()
                 {
-                    auto model             = std::make_unique<DeGrootModel>( network );
-                    model->max_iterations  = degroot_settings.max_iterations;
-                    model->convergence_tol = degroot_settings.convergence_tol;
+                    auto model = std::make_unique<DeGrootModel>( degroot_settings, network );
                     return model;
                 }();
 
@@ -88,10 +86,8 @@ public:
                 // Deffuant model specific parameters
                 model = [&]()
                 {
-                    auto model = std::make_unique<DeffuantModel>( network, gen, deffuant_settings.use_network );
-                    model->max_iterations      = deffuant_settings.max_iterations;
-                    model->homophily_threshold = deffuant_settings.homophily_threshold;
-                    model->mu                  = deffuant_settings.mu;
+                    auto model = std::make_unique<DeffuantModel>(
+                        deffuant_settings, network, gen, deffuant_settings.use_network );
                     return model;
                 }();
 

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -107,40 +107,7 @@ public:
 
             model = [&]()
             {
-                auto model             = std::make_unique<ActivityDrivenModel>( network, gen );
-                model->dt              = activitydriven_settings.dt;
-                model->m               = activitydriven_settings.m;
-                model->eps             = activitydriven_settings.eps;
-                model->gamma           = activitydriven_settings.gamma;
-                model->homophily       = activitydriven_settings.homophily;
-                model->reciprocity     = activitydriven_settings.reciprocity;
-                model->alpha           = activitydriven_settings.alpha;
-                model->K               = activitydriven_settings.K;
-                model->mean_activities = activitydriven_settings.mean_activities;
-                model->mean_weights    = activitydriven_settings.mean_weights;
-                model->max_iterations  = activitydriven_settings.max_iterations;
-                // Reluctance
-                model->use_reluctances  = activitydriven_settings.use_reluctances;
-                model->reluctance_mean  = activitydriven_settings.reluctance_mean;
-                model->reluctance_sigma = activitydriven_settings.reluctance_sigma;
-                model->reluctance_eps   = activitydriven_settings.reluctance_eps;
-                // Bot
-                model->n_bots        = activitydriven_settings.n_bots;
-                model->bot_opinion   = activitydriven_settings.bot_opinion;
-                model->bot_m         = activitydriven_settings.bot_m;
-                model->bot_homophily = activitydriven_settings.bot_homophily;
-                model->bot_activity  = activitydriven_settings.bot_activity;
-                model->get_agents_from_power_law();
-
-                // TODO: this is stupid and should be done in the constructor, but right now it cant since we set mean
-                // weights only later
-                if( model->mean_weights )
-                {
-                    auto agents_copy = network.agents;
-                    network          = NetworkGeneration::generate_fully_connected<AgentType>( network.n_agents() );
-                    network.agents   = agents_copy;
-                }
-
+                auto model = std::make_unique<ActivityDrivenModel>( activitydriven_settings, network, gen );
                 return model;
             }();
 

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -73,11 +73,6 @@ public:
                     auto model = std::make_unique<DeGrootModel>( degroot_settings, network );
                     return model;
                 }();
-
-                if( cli_agent_file.has_value() )
-                {
-                    network.agents = agents_from_file<DeGrootModel::AgentT>( cli_agent_file.value() );
-                }
             }
             else if( options.model == Config::Model::DeffuantModel )
             {
@@ -90,11 +85,6 @@ public:
                         deffuant_settings, network, gen, deffuant_settings.use_network );
                     return model;
                 }();
-
-                if( cli_agent_file.has_value() )
-                {
-                    network.agents = agents_from_file<DeffuantModel::AgentT>( cli_agent_file.value() );
-                }
             }
         }
         else if constexpr( std::is_same_v<AgentType, ActivityDrivenModel::AgentT> )
@@ -106,11 +96,11 @@ public:
                 auto model = std::make_unique<ActivityDrivenModel>( activitydriven_settings, network, gen );
                 return model;
             }();
+        }
 
-            if( cli_agent_file.has_value() )
-            {
-                network.agents = agents_from_file<ActivityDrivenModel::AgentT>( cli_agent_file.value() );
-            }
+        if( cli_agent_file.has_value() )
+        {
+            network.agents = agents_from_file<AgentType>( cli_agent_file.value() );
         }
     }
 

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -108,7 +108,7 @@ public:
                 // Deffuant model specific parameters
                 model = [&]()
                 {
-                    auto model                 = std::make_unique<DeffuantModel>( network, gen );
+                    auto model = std::make_unique<DeffuantModel>( network, gen, deffuant_settings.use_network );
                     model->max_iterations      = deffuant_settings.max_iterations;
                     model->homophily_threshold = deffuant_settings.homophily_threshold;
                     model->mu                  = deffuant_settings.mu;

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -72,7 +72,15 @@ public:
         }
         else if( options.model == Config::Model::DeffuantModel )
         {
-            model = ModelFactory::create_model_deffuant( network, options.model_settings, gen );
+            auto deffuant_settings = std::get<Config::DeffuantSettings>( options.model_settings );
+            if( deffuant_settings.use_binary_vector )
+            {
+                model = ModelFactory::create_model_deffuant_vector( network, options.model_settings, gen );
+            }
+            else
+            {
+                model = ModelFactory::create_model_deffuant( network, options.model_settings, gen );
+            }
         }
 
         if( cli_agent_file.has_value() )

--- a/include/util/math.hpp
+++ b/include/util/math.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <algorithm>
 #include <cstddef>
+#include <optional>
 #include <queue>
 #include <random>
 #include <utility>
@@ -13,7 +14,8 @@ namespace Seldon
 // drawing from n agents (without duplication)
 // ignore_idx ignores the index of the agent itself, since we will later add the agent itself ourselves to prevent duplication
 inline void draw_unique_k_from_n(
-    std::size_t ignore_idx, std::size_t k, std::size_t n, std::vector<std::size_t> & buffer, std::mt19937 & gen )
+    std::optional<size_t> ignore_idx, std::size_t k, std::size_t n, std::vector<std::size_t> & buffer,
+    std::mt19937 & gen )
 {
     struct SequenceGenerator
     {
@@ -24,15 +26,15 @@ inline void draw_unique_k_from_n(
         using pointer           = size_t *; // or also value_type*
         using reference         = size_t &;
 
-        SequenceGenerator( const size_t i_, const size_t ignore_idx ) : i( i_ ), ignore_idx( ignore_idx )
+        SequenceGenerator( const size_t i_, std::optional<size_t> ignore_idx ) : i( i_ ), ignore_idx( ignore_idx )
         {
-            if( i == ignore_idx )
+            if( ignore_idx.has_value() && i == ignore_idx.value() )
             {
                 i++;
             }
         }
         size_t i;
-        size_t ignore_idx;
+        std::optional<size_t> ignore_idx;
 
         size_t & operator*()
         {
@@ -45,7 +47,7 @@ inline void draw_unique_k_from_n(
         SequenceGenerator & operator++()
         {
             i++;
-            if( i == ignore_idx )
+            if( ignore_idx.has_value() && i == ignore_idx )
                 i++;
             return *this;
         }

--- a/include/util/math.hpp
+++ b/include/util/math.hpp
@@ -4,6 +4,8 @@
 #include <optional>
 #include <queue>
 #include <random>
+#include <span>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -173,5 +175,22 @@ public:
         return eps;
     }
 };
+
+template<typename T>
+int hamming_distance( std::span<T> v1, std::span<T> v2 )
+{
+    if( v1.size() != v2.size() )
+    {
+        throw std::runtime_error( "v1 and v2 need to have the same size" );
+    }
+
+    int distance = 0;
+    for( size_t i = 0; i < v2.size(); i++ )
+    {
+        if( v1[i] != v2[i] )
+            distance++;
+    }
+    return distance;
+}
 
 } // namespace Seldon

--- a/include/util/misc.hpp
+++ b/include/util/misc.hpp
@@ -31,4 +31,32 @@ inline std::string get_file_contents( const std::string & filename )
     throw( std::runtime_error( "Cannot read file." ) );
 }
 
+/*
+Executes `callback` for each substring in a comma separated list.
+If the input is "a_d, b, 1", it would call the callback function like 
+so:
+    callback(0, "a d")
+    callback(1, " b")
+    callback(2, " 1")
+*/
+template<typename CallbackT>
+void parse_comma_separated_list( const std::string & str, CallbackT & callback )
+{
+    int idx_entry = 0;
+    auto pos_cur  = -1; // Have to initialize from -1, because we start looking one past pos_cur
+    while( true )
+    {
+        auto pos_next = str.find( ',', pos_cur + 1 );
+        auto substr   = str.substr( pos_cur + 1, pos_next );
+        callback( idx_entry, substr );
+
+        pos_cur = pos_next;
+        idx_entry++;
+        if( pos_next == std::string::npos )
+        {
+            break;
+        }
+    }
+}
+
 } // namespace Seldon

--- a/include/util/misc.hpp
+++ b/include/util/misc.hpp
@@ -33,7 +33,7 @@ inline std::string get_file_contents( const std::string & filename )
 
 /*
 Executes `callback` for each substring in a comma separated list.
-If the input is "a_d, b, 1", it would call the callback function like 
+If the input is "a_d, b, 1", it would call the callback function like
 so:
     callback(0, "a d")
     callback(1, " b")

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ sources_seldon = [
   'src/config_parser.cpp',
   'src/models/DeGroot.cpp',
   'src/models/ActivityDrivenModel.cpp',
+  'src/models/DeffuantModel.cpp',
   'src/util/tomlplusplus.cpp',
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ tests = [
   ['Test_Network_Generation', 'test/test_network_generation.cpp'],
   ['Test_Sampling', 'test/test_sampling.cpp'],
   ['Test_IO', 'test/test_io.cpp'],
+  ['Test_Util', 'test/test_util.cpp'],
 ]
 
 Catch2 = dependency('Catch2', method : 'cmake', modules : ['Catch2::Catch2WithMain', 'Catch2::Catch2'])

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ sources_seldon = [
   'src/models/DeGroot.cpp',
   'src/models/ActivityDrivenModel.cpp',
   'src/models/DeffuantModel.cpp',
+  'src/models/DeffuantModelVector.cpp',
   'src/util/tomlplusplus.cpp',
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ tests = [
   ['Test_Tarjan', 'test/test_tarjan.cpp'],
   ['Test_DeGroot', 'test/test_deGroot.cpp'],
   ['Test_Activity_Driven', 'test/test_activity.cpp'],
+  ['Test_Deffuant', 'test/test_deffuant.cpp'],
   ['Test_Network', 'test/test_network.cpp'],
   ['Test_Network_Generation', 'test/test_network_generation.cpp'],
   ['Test_Sampling', 'test/test_sampling.cpp'],

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -77,6 +77,7 @@ SimulationOptions parse_config_file( std::string_view config_file_path )
         model_settings.max_iterations = tbl["model"]["max_iterations"].value<int>();
         set_if_specified( model_settings.homophily_threshold, tbl[options.model_string]["homophily_threshold"] );
         set_if_specified( model_settings.mu, tbl[options.model_string]["mu"] );
+        set_if_specified( model_settings.use_network, tbl[options.model_string]["use_network"] );
         options.model_settings = model_settings;
     }
     else if( options.model == Model::ActivityDrivenModel )
@@ -270,6 +271,7 @@ void print_settings( const SimulationOptions & options )
         fmt::print( "    max_iterations {}\n", model_settings.max_iterations );
         fmt::print( "    homophily_threshold {}\n", model_settings.homophily_threshold );
         fmt::print( "    mu {}\n", model_settings.mu );
+        fmt::print( "    use_network {}\n", model_settings.use_network );
     }
 
     fmt::print( "[Network]\n" );

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -25,6 +25,10 @@ Model model_string_to_enum( std::string_view model_string )
     {
         return Model::ActivityDrivenModel;
     }
+    else if( model_string == "Deffuant" )
+    {
+        return Model::DeffuantModel;
+    }
     throw std::runtime_error( fmt::format( "Invalid model string {}", model_string ) );
 }
 
@@ -62,36 +66,44 @@ SimulationOptions parse_config_file( std::string_view config_file_path )
 
     if( options.model == Model::DeGroot )
     {
-        auto model_settings            = DeGrootSettings();
-        model_settings.max_iterations  = tbl["model"]["max_iterations"].value<int>();
-        model_settings.convergence_tol = tbl["DeGroot"]["convergence"].value_or( model_settings.convergence_tol );
-        options.model_settings         = model_settings;
+        auto model_settings           = DeGrootSettings();
+        model_settings.max_iterations = tbl["model"]["max_iterations"].value<int>();
+        set_if_specified( model_settings.convergence_tol, tbl[options.model_string]["convergence"] );
+        options.model_settings = model_settings;
+    }
+    else if( options.model == Model::DeffuantModel )
+    {
+        auto model_settings           = DeffuantSettings();
+        model_settings.max_iterations = tbl["model"]["max_iterations"].value<int>();
+        set_if_specified( model_settings.homophily_threshold, tbl[options.model_string]["homophily_threshold"] );
+        set_if_specified( model_settings.mu, tbl[options.model_string]["mu"] );
+        options.model_settings = model_settings;
     }
     else if( options.model == Model::ActivityDrivenModel )
     {
         auto model_settings = ActivityDrivenSettings();
 
-        set_if_specified( model_settings.dt, tbl["ActivityDriven"]["dt"] );
-        set_if_specified( model_settings.m, tbl["ActivityDriven"]["m"] );
-        set_if_specified( model_settings.eps, tbl["ActivityDriven"]["eps"] );
-        set_if_specified( model_settings.gamma, tbl["ActivityDriven"]["gamma"] );
-        set_if_specified( model_settings.homophily, tbl["ActivityDriven"]["homophily"] );
-        set_if_specified( model_settings.reciprocity, tbl["ActivityDriven"]["reciprocity"] );
-        set_if_specified( model_settings.alpha, tbl["ActivityDriven"]["alpha"] );
-        set_if_specified( model_settings.K, tbl["ActivityDriven"]["K"] );
+        set_if_specified( model_settings.dt, tbl[options.model_string]["dt"] );
+        set_if_specified( model_settings.m, tbl[options.model_string]["m"] );
+        set_if_specified( model_settings.eps, tbl[options.model_string]["eps"] );
+        set_if_specified( model_settings.gamma, tbl[options.model_string]["gamma"] );
+        set_if_specified( model_settings.homophily, tbl[options.model_string]["homophily"] );
+        set_if_specified( model_settings.reciprocity, tbl[options.model_string]["reciprocity"] );
+        set_if_specified( model_settings.alpha, tbl[options.model_string]["alpha"] );
+        set_if_specified( model_settings.K, tbl[options.model_string]["K"] );
         // Mean activity model options
-        set_if_specified( model_settings.mean_activities, tbl["ActivityDriven"]["mean_activities"] );
-        set_if_specified( model_settings.mean_weights, tbl["ActivityDriven"]["mean_weights"] );
+        set_if_specified( model_settings.mean_activities, tbl[options.model_string]["mean_activities"] );
+        set_if_specified( model_settings.mean_weights, tbl[options.model_string]["mean_weights"] );
         // Reluctances
-        set_if_specified( model_settings.use_reluctances, tbl["ActivityDriven"]["reluctances"] );
-        set_if_specified( model_settings.reluctance_mean, tbl["ActivityDriven"]["reluctance_mean"] );
-        set_if_specified( model_settings.reluctance_sigma, tbl["ActivityDriven"]["reluctance_sigma"] );
-        set_if_specified( model_settings.reluctance_eps, tbl["ActivityDriven"]["reluctance_eps"] );
+        set_if_specified( model_settings.use_reluctances, tbl[options.model_string]["reluctances"] );
+        set_if_specified( model_settings.reluctance_mean, tbl[options.model_string]["reluctance_mean"] );
+        set_if_specified( model_settings.reluctance_sigma, tbl[options.model_string]["reluctance_sigma"] );
+        set_if_specified( model_settings.reluctance_eps, tbl[options.model_string]["reluctance_eps"] );
 
         model_settings.max_iterations = tbl["model"]["max_iterations"].value<int>();
 
         // bot
-        set_if_specified( model_settings.n_bots, tbl["ActivityDriven"]["n_bots"] );
+        set_if_specified( model_settings.n_bots, tbl[options.model_string]["n_bots"] );
 
         auto push_back_bot_array = [&]( auto toml_node, auto & options_array, auto default_value )
         {
@@ -118,10 +130,10 @@ SimulationOptions parse_config_file( std::string_view config_file_path )
             }
         };
 
-        auto bot_opinion   = tbl["ActivityDriven"]["bot_opinion"];
-        auto bot_m         = tbl["ActivityDriven"]["bot_m"];
-        auto bot_activity  = tbl["ActivityDriven"]["bot_activity"];
-        auto bot_homophily = tbl["ActivityDriven"]["bot_homophily"];
+        auto bot_opinion   = tbl[options.model_string]["bot_opinion"];
+        auto bot_m         = tbl[options.model_string]["bot_m"];
+        auto bot_activity  = tbl[options.model_string]["bot_activity"];
+        auto bot_homophily = tbl[options.model_string]["bot_homophily"];
 
         push_back_bot_array( bot_m, model_settings.bot_m, model_settings.m );
         push_back_bot_array( bot_opinion, model_settings.bot_opinion, 0.0 );
@@ -197,6 +209,12 @@ void validate_settings( const SimulationOptions & options )
         auto model_settings = std::get<DeGrootSettings>( options.model_settings );
         check( name_and_var( model_settings.convergence_tol ), geq_zero );
     }
+    else if( options.model == Model::DeffuantModel )
+    {
+        auto model_settings = std::get<DeffuantSettings>( options.model_settings );
+        check( name_and_var( model_settings.homophily_threshold ), g_zero );
+        check( name_and_var( model_settings.mu ), []( auto x ) { return x >= 0 && x <= 1; } );
+    }
 }
 
 void print_settings( const SimulationOptions & options )
@@ -245,6 +263,13 @@ void print_settings( const SimulationOptions & options )
         auto model_settings = std::get<DeGrootSettings>( options.model_settings );
         fmt::print( "    max_iterations {}\n", model_settings.max_iterations );
         fmt::print( "    convergence_tol {}\n", model_settings.convergence_tol );
+    }
+    else if( options.model == Model::DeffuantModel )
+    {
+        auto model_settings = std::get<DeffuantSettings>( options.model_settings );
+        fmt::print( "    max_iterations {}\n", model_settings.max_iterations );
+        fmt::print( "    homophily_threshold {}\n", model_settings.homophily_threshold );
+        fmt::print( "    mu {}\n", model_settings.mu );
     }
 
     fmt::print( "[Network]\n" );

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -78,6 +78,9 @@ SimulationOptions parse_config_file( std::string_view config_file_path )
         set_if_specified( model_settings.homophily_threshold, tbl[options.model_string]["homophily_threshold"] );
         set_if_specified( model_settings.mu, tbl[options.model_string]["mu"] );
         set_if_specified( model_settings.use_network, tbl[options.model_string]["use_network"] );
+        // Options for the DeffuantModelVector model
+        set_if_specified( model_settings.use_binary_vector, tbl[options.model_string]["binary_vector"] );
+        set_if_specified( model_settings.dim, tbl[options.model_string]["dim"] );
         options.model_settings = model_settings;
     }
     else if( options.model == Model::ActivityDrivenModel )
@@ -215,6 +218,15 @@ void validate_settings( const SimulationOptions & options )
         auto model_settings = std::get<DeffuantSettings>( options.model_settings );
         check( name_and_var( model_settings.homophily_threshold ), g_zero );
         check( name_and_var( model_settings.mu ), []( auto x ) { return x >= 0 && x <= 1; } );
+        // DeffuantModelVector settings
+        check( name_and_var( model_settings.dim ), g_zero );
+        // @TODO: maybe make this check nicer?
+        if( !model_settings.use_binary_vector )
+        {
+            const std::string basic_deff_msg
+                = "The basic Deffuant model has not been implemented with multiple dimensions";
+            check( name_and_var( model_settings.dim ), []( auto x ) { return x == 1; }, basic_deff_msg );
+        }
     }
 }
 
@@ -272,6 +284,8 @@ void print_settings( const SimulationOptions & options )
         fmt::print( "    homophily_threshold {}\n", model_settings.homophily_threshold );
         fmt::print( "    mu {}\n", model_settings.mu );
         fmt::print( "    use_network {}\n", model_settings.use_network );
+        fmt::print( "    use_binary_vector {}\n", model_settings.use_binary_vector );
+        fmt::print( "    dim {}\n", model_settings.dim );
     }
 
     fmt::print( "[Network]\n" );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "config_parser.hpp"
 #include "models/DeGroot.hpp"
+#include "models/DeffuantModel.hpp"
 #include "simulation.hpp"
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -68,6 +69,15 @@ int main( int argc, char * argv[] )
     {
         simulation = std::make_unique<Seldon::Simulation<Seldon::ActivityDrivenModel::AgentT>>(
             simulation_options, network_file, agent_file );
+    }
+    else if( simulation_options.model == Seldon::Config::Model::DeffuantModel )
+    {
+        simulation = std::make_unique<Seldon::Simulation<Seldon::DeffuantModel::AgentT>>(
+            simulation_options, network_file, agent_file );
+    }
+    else
+    {
+        throw std::runtime_error( "Model has not been created" );
     }
 
     simulation->run( output_dir_path );

--- a/src/models/ActivityDrivenModel.cpp
+++ b/src/models/ActivityDrivenModel.cpp
@@ -9,12 +9,33 @@
 namespace Seldon
 {
 
-ActivityDrivenModel::ActivityDrivenModel( NetworkT & network, std::mt19937 & gen )
-        : Model<ActivityDrivenModel::AgentT>(),
+ActivityDrivenModel::ActivityDrivenModel(
+    const Config::ActivityDrivenSettings & settings, NetworkT & network, std::mt19937 & gen )
+        : Model<ActivityDrivenModel::AgentT>( settings.max_iterations ),
           network( network ),
           contact_prob_list( std::vector<std::vector<NetworkT::WeightT>>( network.n_agents() ) ),
-          gen( gen )
+          gen( gen ),
+          dt( settings.dt ),
+          m( settings.m ),
+          eps( settings.eps ),
+          gamma( settings.gamma ),
+          alpha( settings.alpha ),
+          homophily( settings.homophily ),
+          reciprocity( settings.reciprocity ),
+          K( settings.K ),
+          mean_activities( settings.mean_activities ),
+          mean_weights( settings.mean_weights ),
+          use_reluctances( settings.use_reluctances ),
+          reluctance_mean( settings.reluctance_mean ),
+          reluctance_sigma( settings.reluctance_sigma ),
+          reluctance_eps( settings.reluctance_eps ),
+          n_bots( settings.n_bots ),
+          bot_m( settings.bot_m ),
+          bot_activity( settings.bot_activity ),
+          bot_opinion( settings.bot_opinion ),
+          bot_homophily( settings.bot_homophily )
 {
+    get_agents_from_power_law();
 
     if( mean_weights )
     {
@@ -160,8 +181,7 @@ void ActivityDrivenModel::update_network_mean()
         contact_prob_list[idx_agent] = weights; // set to zero
     }
 
-    auto probability_helper = []( double omega, size_t m )
-    {
+    auto probability_helper = []( double omega, size_t m ) {
         double p = 0;
         for( size_t i = 1; i <= m; i++ )
             p += ( std::pow( -omega, i + 1 ) + omega ) / ( omega + 1 );

--- a/src/models/ActivityDrivenModel.cpp
+++ b/src/models/ActivityDrivenModel.cpp
@@ -181,7 +181,8 @@ void ActivityDrivenModel::update_network_mean()
         contact_prob_list[idx_agent] = weights; // set to zero
     }
 
-    auto probability_helper = []( double omega, size_t m ) {
+    auto probability_helper = []( double omega, size_t m )
+    {
         double p = 0;
         for( size_t i = 1; i <= m; i++ )
             p += ( std::pow( -omega, i + 1 ) + omega ) / ( omega + 1 );

--- a/src/models/ActivityDrivenModel.cpp
+++ b/src/models/ActivityDrivenModel.cpp
@@ -1,5 +1,6 @@
 #include "models/ActivityDrivenModel.hpp"
 #include "network.hpp"
+#include "network_generation.hpp"
 #include "util/math.hpp"
 #include <cstddef>
 #include <random>
@@ -14,6 +15,13 @@ ActivityDrivenModel::ActivityDrivenModel( NetworkT & network, std::mt19937 & gen
           contact_prob_list( std::vector<std::vector<NetworkT::WeightT>>( network.n_agents() ) ),
           gen( gen )
 {
+
+    if( mean_weights )
+    {
+        auto agents_copy = network.agents;
+        network          = NetworkGeneration::generate_fully_connected<AgentT>( network.n_agents() );
+        network.agents   = agents_copy;
+    }
 }
 
 double ActivityDrivenModel::homophily_weight( size_t idx_contacter, size_t idx_contacted )

--- a/src/models/DeGroot.cpp
+++ b/src/models/DeGroot.cpp
@@ -1,12 +1,16 @@
 #include "models/DeGroot.hpp"
+#include "config_parser.hpp"
 #include <cmath>
 #include <iterator>
 
 namespace Seldon
 {
 
-DeGrootModel::DeGrootModel( NetworkT & network )
-        : Model<AgentT>(), network( network ), agents_current_copy( network.agents )
+DeGrootModel::DeGrootModel( Config::DeGrootSettings settings, NetworkT & network )
+        : Model<AgentT>( settings.max_iterations ),
+          convergence_tol( settings.convergence_tol ),
+          network( network ),
+          agents_current_copy( network.agents )
 {
     // For a strongly connected network, the number of SCCs should be 1
     // Print a warning if this is not true

--- a/src/models/DeffuantModel.cpp
+++ b/src/models/DeffuantModel.cpp
@@ -1,94 +1,33 @@
 #include "models/DeffuantModel.hpp"
-#include "network.hpp"
-#include "network_generation.hpp"
-#include "util/math.hpp"
 #include <cmath>
 #include <cstddef>
-#include <optional>
-#include <random>
-#include <stdexcept>
 #include <vector>
 
 namespace Seldon
 {
 
-DeffuantModel::DeffuantModel( NetworkT & network, std::mt19937 & gen, bool use_network )
-        : Model<DeffuantModel::AgentT>(), use_network( use_network ), network( network ), gen( gen )
+template<>
+void DeffuantModelAbstract<SimpleAgent>::initialize_agents()
 {
-    // Generate the network as a square lattice if use_network is true
-    if( use_network )
-    {
-        size_t n_edge = std::sqrt( network.n_agents() );
-        if( n_edge * n_edge != network.n_agents() )
-        {
-            throw std::runtime_error( "Number of agents is not a square number." );
-        }
-        network = NetworkGeneration::generate_square_lattice<AgentT>( n_edge );
-    }
-
     for( size_t i = 0; i < network.agents.size(); i++ )
     {
         network.agents[i].data.opinion = double( i ) / double( network.agents.size() );
     }
 }
 
-std::vector<std::size_t> DeffuantModel::select_interacting_agent_pair()
+template<>
+void DeffuantModelAbstract<SimpleAgent>::update_rule( AgentT & agent1, AgentT & agent2 )
 {
-
-    auto interacting_agents = std::vector<std::size_t>();
-
-    // If the basic model is being used, then search from all possible agents
-    if( !use_network )
+    // Update rule
+    auto opinion_diff = agent1.data.opinion - agent2.data.opinion;
+    // Only if less than homophily_threshold
+    if( std::abs( opinion_diff ) < homophily_threshold )
     {
-
-        // Pick any two agents to interact, randomly, without repetition
-        draw_unique_k_from_n( std::nullopt, 2, network.n_agents(), interacting_agents, gen );
-
-        return interacting_agents;
-    }
-    else
-    {
-        // First select an agent randomly
-        auto dist       = std::uniform_int_distribution<size_t>( 0, network.n_agents() - 1 );
-        auto agent1_idx = dist( gen );
-        interacting_agents.push_back( agent1_idx );
-
-        // Choose a neighbour randomly from the neighbour list of agent1_idx
-        auto neighbours     = network.get_neighbours( agent1_idx );
-        auto n_neighbours   = neighbours.size();
-        auto dist_n         = std::uniform_int_distribution<size_t>( 0, n_neighbours - 1 );
-        auto index_in_neigh = dist_n( gen ); // Index inside neighbours list
-        auto agent2_idx     = neighbours[index_in_neigh];
-        interacting_agents.push_back( agent2_idx );
-
-        return interacting_agents;
+        agent1.data.opinion -= mu * opinion_diff;
+        agent2.data.opinion += mu * opinion_diff;
     }
 }
 
-void DeffuantModel::iteration()
-{
-    Model<AgentT>::iteration(); // Update n_iterations
+template class DeffuantModelAbstract<SimpleAgent>;
 
-    // Although the model defines each iteration as choosing *one*
-    // pair of agents, we will define each iteration as sampling
-    // n_agents pairs (similar to the time unit in evolution plots in the paper)
-    for( size_t i = 0; i < network.n_agents(); i++ )
-    {
-
-        auto interacting_agents = select_interacting_agent_pair();
-
-        auto & agent1 = network.agents[interacting_agents[0]];
-        auto & agent2 = network.agents[interacting_agents[1]];
-
-        // Update rule
-        auto opinion_diff = agent1.data.opinion - agent2.data.opinion;
-
-        // Only if less than homophily_threshold
-        if( std::abs( opinion_diff ) < homophily_threshold )
-        {
-            agent1.data.opinion -= mu * opinion_diff;
-            agent2.data.opinion += mu * opinion_diff;
-        }
-    }
-}
 } // namespace Seldon

--- a/src/models/DeffuantModel.cpp
+++ b/src/models/DeffuantModel.cpp
@@ -1,17 +1,31 @@
 #include "models/DeffuantModel.hpp"
 #include "network.hpp"
+#include "network_generation.hpp"
 #include "util/math.hpp"
+#include <cmath>
 #include <cstddef>
 #include <optional>
 #include <random>
+#include <stdexcept>
 #include <vector>
 
 namespace Seldon
 {
 
-DeffuantModel::DeffuantModel( NetworkT & network, std::mt19937 & gen )
-        : Model<DeffuantModel::AgentT>(), network( network ), gen( gen )
+DeffuantModel::DeffuantModel( NetworkT & network, std::mt19937 & gen, bool use_network )
+        : Model<DeffuantModel::AgentT>(), use_network( use_network ), network( network ), gen( gen )
 {
+    // Generate the network as a square lattice if use_network is true
+    if( use_network )
+    {
+        size_t n_edge = std::sqrt( network.n_agents() );
+        if( n_edge * n_edge != network.n_agents() )
+        {
+            throw std::runtime_error( "Number of agents is not a square number." );
+        }
+        network = NetworkGeneration::generate_square_lattice<AgentT>( n_edge );
+    }
+
     for( size_t i = 0; i < network.agents.size(); i++ )
     {
         network.agents[i].data.opinion = double( i ) / double( network.agents.size() );

--- a/src/models/DeffuantModel.cpp
+++ b/src/models/DeffuantModel.cpp
@@ -1,0 +1,45 @@
+#include "models/DeffuantModel.hpp"
+#include "network.hpp"
+#include "util/math.hpp"
+#include <cstddef>
+#include <optional>
+#include <random>
+#include <vector>
+
+namespace Seldon
+{
+
+DeffuantModel::DeffuantModel( NetworkT & network, std::mt19937 & gen )
+        : Model<DeffuantModel::AgentT>(), network( network ), gen( gen )
+{
+}
+
+void DeffuantModel::iteration()
+{
+    Model<AgentT>::iteration(); // Update n_iterations
+
+    // Although the model defines each iteration as choosing *one*
+    // pair of agents, we will define each iteration as sampling
+    // n_agents pairs (similar to the time unit in evolution plots in the paper)
+    for( size_t i = 0; i < network.n_agents(); i++ )
+    {
+
+        auto interacting_agents = std::vector<std::size_t>();
+
+        // Pick any two agents to interact, randomly, without repetition
+        draw_unique_k_from_n( std::nullopt, 2, network.n_agents(), interacting_agents, gen );
+
+        auto & agent1 = network.agents[interacting_agents[0]];
+        auto & agent2 = network.agents[interacting_agents[1]];
+
+        // Update rule
+        auto opinion_diff = agent1.data.opinion - agent2.data.opinion;
+        // Only if less than homophily_threshold
+        if( std::abs( opinion_diff ) < homophily_threshold )
+        {
+            agent1.data.opinion -= mu * opinion_diff;
+            agent2.data.opinion += mu * opinion_diff;
+        }
+    }
+}
+} // namespace Seldon

--- a/src/models/DeffuantModel.cpp
+++ b/src/models/DeffuantModel.cpp
@@ -18,6 +18,39 @@ DeffuantModel::DeffuantModel( NetworkT & network, std::mt19937 & gen )
     }
 }
 
+std::vector<std::size_t> DeffuantModel::select_interacting_agent_pair()
+{
+
+    auto interacting_agents = std::vector<std::size_t>();
+
+    // If the basic model is being used, then search from all possible agents
+    if( !use_network )
+    {
+
+        // Pick any two agents to interact, randomly, without repetition
+        draw_unique_k_from_n( std::nullopt, 2, network.n_agents(), interacting_agents, gen );
+
+        return interacting_agents;
+    }
+    else
+    {
+        // First select an agent randomly
+        auto dist       = std::uniform_int_distribution<size_t>( 0, network.n_agents() - 1 );
+        auto agent1_idx = dist( gen );
+        interacting_agents.push_back( agent1_idx );
+
+        // Choose a neighbour randomly from the neighbour list of agent1_idx
+        auto neighbours     = network.get_neighbours( agent1_idx );
+        auto n_neighbours   = neighbours.size();
+        auto dist_n         = std::uniform_int_distribution<size_t>( 0, n_neighbours - 1 );
+        auto index_in_neigh = dist_n( gen ); // Index inside neighbours list
+        auto agent2_idx     = neighbours[index_in_neigh];
+        interacting_agents.push_back( agent2_idx );
+
+        return interacting_agents;
+    }
+}
+
 void DeffuantModel::iteration()
 {
     Model<AgentT>::iteration(); // Update n_iterations
@@ -28,10 +61,7 @@ void DeffuantModel::iteration()
     for( size_t i = 0; i < network.n_agents(); i++ )
     {
 
-        auto interacting_agents = std::vector<std::size_t>();
-
-        // Pick any two agents to interact, randomly, without repetition
-        draw_unique_k_from_n( std::nullopt, 2, network.n_agents(), interacting_agents, gen );
+        auto interacting_agents = select_interacting_agent_pair();
 
         auto & agent1 = network.agents[interacting_agents[0]];
         auto & agent2 = network.agents[interacting_agents[1]];

--- a/src/models/DeffuantModel.cpp
+++ b/src/models/DeffuantModel.cpp
@@ -7,7 +7,7 @@ namespace Seldon
 {
 
 template<>
-void DeffuantModelAbstract<SimpleAgent>::initialize_agents()
+void DeffuantModelAbstract<SimpleAgent>::initialize_agents( size_t )
 {
     for( size_t i = 0; i < network.agents.size(); i++ )
     {

--- a/src/models/DeffuantModel.cpp
+++ b/src/models/DeffuantModel.cpp
@@ -12,6 +12,10 @@ namespace Seldon
 DeffuantModel::DeffuantModel( NetworkT & network, std::mt19937 & gen )
         : Model<DeffuantModel::AgentT>(), network( network ), gen( gen )
 {
+    for( size_t i = 0; i < network.agents.size(); i++ )
+    {
+        network.agents[i].data.opinion = double( i ) / double( network.agents.size() );
+    }
 }
 
 void DeffuantModel::iteration()
@@ -34,6 +38,7 @@ void DeffuantModel::iteration()
 
         // Update rule
         auto opinion_diff = agent1.data.opinion - agent2.data.opinion;
+
         // Only if less than homophily_threshold
         if( std::abs( opinion_diff ) < homophily_threshold )
         {

--- a/src/models/DeffuantModelVector.cpp
+++ b/src/models/DeffuantModelVector.cpp
@@ -10,10 +10,9 @@ namespace Seldon
 {
 
 template<>
-void DeffuantModelAbstract<DiscreteVectorAgent>::initialize_agents()
+void DeffuantModelAbstract<DiscreteVectorAgent>::initialize_agents( size_t dim )
 {
     std::uniform_int_distribution<int> dist( 0, 1 );
-    int dim = 5;
 
     for( size_t i = 0; i < network.agents.size(); i++ )
     {

--- a/src/models/DeffuantModelVector.cpp
+++ b/src/models/DeffuantModelVector.cpp
@@ -1,0 +1,34 @@
+#include "agents/discrete_vector_agent.hpp"
+#include "models/DeffuantModel.hpp"
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace Seldon
+{
+
+template<>
+void DeffuantModelAbstract<DiscreteVectorAgent>::initialize_agents()
+{
+    for( size_t i = 0; i < network.agents.size(); i++ )
+    {
+        // network.agents[i].data.opinion = double( i ) / double( network.agents.size() );
+    }
+}
+
+template<>
+void DeffuantModelAbstract<DiscreteVectorAgent>::update_rule( AgentT & agent1, AgentT & agent2 )
+{
+    // Update rule
+    // auto opinion_diff = agent1.data.opinion - agent2.data.opinion;
+    // Only if less than homophily_threshold
+    // if( std::abs( opinion_diff ) < homophily_threshold )
+    // {
+        // agent1.data.opinion -= mu * opinion_diff;
+    //     agent2.data.opinion += mu * opinion_diff;
+    // }
+}
+
+template class DeffuantModelAbstract<DiscreteVectorAgent>;
+
+} // namespace Seldon

--- a/src/models/DeffuantModelVector.cpp
+++ b/src/models/DeffuantModelVector.cpp
@@ -1,7 +1,9 @@
+#include "agent.hpp"
 #include "agents/discrete_vector_agent.hpp"
 #include "models/DeffuantModel.hpp"
-#include <cmath>
+#include "util/math.hpp"
 #include <cstddef>
+#include <random>
 #include <vector>
 
 namespace Seldon
@@ -10,23 +12,53 @@ namespace Seldon
 template<>
 void DeffuantModelAbstract<DiscreteVectorAgent>::initialize_agents()
 {
+    std::uniform_int_distribution<int> dist( 0, 1 );
+    int dim = 5;
+
     for( size_t i = 0; i < network.agents.size(); i++ )
     {
-        // network.agents[i].data.opinion = double( i ) / double( network.agents.size() );
+        auto & opinion = network.agents[i].data.opinion;
+        opinion.resize( dim );
+        for( auto & o : opinion )
+        {
+            o = dist( gen );
+        }
     }
 }
 
 template<>
 void DeffuantModelAbstract<DiscreteVectorAgent>::update_rule( AgentT & agent1, AgentT & agent2 )
 {
+    size_t dim      = agent1.data.opinion.size();
+    auto & opinion1 = agent1.data.opinion;
+    auto & opinion2 = agent2.data.opinion;
+
+    auto distance = hamming_distance( std::span( opinion1 ), std::span( opinion2 ) );
+
+    std::uniform_int_distribution<> dist_pair( 0, 1 );
+    std::uniform_real_distribution<> dist_convince( 0, 1 );
+
     // Update rule
-    // auto opinion_diff = agent1.data.opinion - agent2.data.opinion;
     // Only if less than homophily_threshold
-    // if( std::abs( opinion_diff ) < homophily_threshold )
-    // {
-        // agent1.data.opinion -= mu * opinion_diff;
-    //     agent2.data.opinion += mu * opinion_diff;
-    // }
+    if( distance < homophily_threshold )
+    {
+        for( size_t idx_opinion = 0; idx_opinion < dim; idx_opinion++ )
+        {
+            if( opinion1[idx_opinion] != opinion2[idx_opinion] )
+            {
+                // randomly select one of the
+                auto idx_selected = dist_pair( gen );
+                if( idx_selected == 0 && mu < dist_convince( gen ) )
+                {
+                    opinion1[idx_opinion] = opinion2[idx_opinion];
+                }
+                else
+                {
+                    opinion2[idx_opinion] = opinion1[idx_opinion];
+                }
+            }
+        }
+    }
 }
 
 template class DeffuantModelAbstract<DiscreteVectorAgent>;

--- a/test/res/deffuant_16x16_agents.toml
+++ b/test/res/deffuant_16x16_agents.toml
@@ -1,0 +1,22 @@
+[simulation]
+model = "Deffuant"
+# rng_seed = 120 # Leaving this empty will pick a random seed
+
+[io]
+# n_output_network = 20 # Write the network every 20 iterations
+# n_output_agents = 1 # Write the opinions of agents after every iteration
+# print_progress = false # Print the iteration time ; if not set, then does not prints
+# output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
+# start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+
+[model]
+max_iterations = 10000 # If not set, max iterations is infinite
+
+[Deffuant]
+homophily_threshold = 1.0 # d in the paper; agents interact if difference in opinion is less than this value 
+mu = 0.5                  # convergence parameter; similar to social interaction strength K (0,0.5] 
+use_network = true
+
+[network]
+number_of_agents = 256
+connections_per_agent = 0

--- a/test/res/deffuant_2agents.toml
+++ b/test/res/deffuant_2agents.toml
@@ -1,0 +1,21 @@
+[simulation]
+model = "Deffuant"
+# rng_seed = 120 # Leaving this empty will pick a random seed
+
+[io]
+# n_output_network = 20 # Write the network every 20 iterations
+# n_output_agents = 1 # Write the opinions of agents after every iteration
+# print_progress = false # Print the iteration time ; if not set, then does not prints
+# output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
+# start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+
+[model]
+max_iterations = 10 # If not set, max iterations is infinite
+
+[Deffuant]
+homophily_threshold = 0.2 # d in the paper; agents interact if difference in opinion is less than this value 
+mu = 0.5 # convergence parameter; similar to social interaction strength K (0,0.5] 
+
+[network]
+number_of_agents = 2
+connections_per_agent = 0

--- a/test/res/deffuant_vector_2agents.toml
+++ b/test/res/deffuant_vector_2agents.toml
@@ -1,0 +1,24 @@
+[simulation]
+model = "Deffuant"
+# rng_seed = 120 # Leaving this empty will pick a random seed
+
+[io]
+# n_output_network = 20 # Write the network every 20 iterations
+# n_output_agents = 1 # Write the opinions of agents after every iteration
+# print_progress = false # Print the iteration time ; if not set, then does not prints
+# output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
+# start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+
+[model]
+max_iterations = 10 # If not set, max iterations is infinite
+
+[Deffuant]
+homophily_threshold = 2 # d in the paper; agents interact if difference in opinion is less than this value 
+mu = 0.5 # convergence parameter; similar to social interaction strength K (0,0.5] 
+use_network = false # If true, will use a square lattice Will throw if sqrt(n_agents) is not an integer
+binary_vector = true # If true, this will be the multi-dimensional binary vector Deffuant model
+dim = 3 # For the multi-dimensional binary vector Deffuant model, define the number of dimensions in each opinion vector
+
+[network]
+number_of_agents = 2
+connections_per_agent = 0

--- a/test/test_deGroot.cpp
+++ b/test/test_deGroot.cpp
@@ -23,11 +23,15 @@ TEST_CASE( "Test the DeGroot Model Symmetric", "[DeGroot]" )
         { 0.2, 0.8 },
     };
 
-    auto network = Network( std::move( neighbour_list ), std::move( weight_list ), Network::EdgeDirection::Incoming );
-    auto model   = DeGrootModel( network );
+    auto settings = Config::DeGrootSettings();
 
-    model.convergence_tol          = 1e-6;
-    model.max_iterations           = 100;
+    auto network = Network( std::move( neighbour_list ), std::move( weight_list ), Network::EdgeDirection::Incoming );
+
+    settings.convergence_tol = 1e-6;
+    settings.max_iterations  = 100;
+
+    auto model = DeGrootModel( settings, network );
+
     network.agents[0].data.opinion = 0.0;
     network.agents[1].data.opinion = 1.0;
 
@@ -36,10 +40,11 @@ TEST_CASE( "Test the DeGroot Model Symmetric", "[DeGroot]" )
         model.iteration();
     }
 
-    INFO( fmt::format( "N_iterations = {} (with convergence_tol {})\n", model.n_iterations(), model.convergence_tol ) );
+    INFO( fmt::format(
+        "N_iterations = {} (with convergence_tol {})\n", model.n_iterations(), settings.convergence_tol ) );
     for( size_t i = 0; i < n_agents; i++ )
     {
         INFO( fmt::format( "Opinion {} = {}\n", i, network.agents[i].data.opinion ) );
-        REQUIRE_THAT( network.agents[i].data.opinion, WithinAbs( 0.5, model.convergence_tol * 10.0 ) );
+        REQUIRE_THAT( network.agents[i].data.opinion, WithinAbs( 0.5, settings.convergence_tol * 10.0 ) );
     }
 }

--- a/test/test_deffuant.cpp
+++ b/test/test_deffuant.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <config_parser.hpp>
+#include <cstddef>
 #include <filesystem>
 #include <network_io.hpp>
 #include <optional>
@@ -59,4 +60,56 @@ TEST_CASE( "Test the basic deffuant model for two agents", "[deffuantTwoAgents]"
     double expected_diff = std::pow( 1.0 - 2.0 * mu, 2 * n_iterations ) * ( agent1_init - agent2_init );
 
     REQUIRE_THAT( agent1_opinion - agent2_opinion, WithinRel( expected_diff ) );
+}
+
+TEST_CASE( "Test the lattice deffuant model for 16x16 agents", "[deffuantLattice16x16]" )
+{
+    using namespace Seldon;
+    using namespace Catch::Matchers;
+    using AgentT = DeffuantModel::AgentT;
+
+    auto proj_root_path = fs::current_path();
+    auto input_file     = proj_root_path / fs::path( "test/res/deffuant_16x16_agents.toml" );
+
+    auto options = Config::parse_config_file( input_file.string() );
+
+    auto simulation = Simulation<AgentT>( options, std::nullopt, std::nullopt );
+
+    // We need an output path for Simulation, but we won't write anything out there
+    fs::path output_dir_path = proj_root_path / fs::path( "test/output_deffuant" );
+
+    auto model_settings      = std::get<Seldon::Config::DeffuantSettings>( options.model_settings );
+    auto homophily_threshold = model_settings.homophily_threshold;
+
+    auto n_agents = simulation.network.n_agents();
+
+    // first half with low opinions
+    size_t n_agents_half = n_agents / 2;
+    double avg_opinion   = 0;
+    for( size_t idx_agent = 0; idx_agent < n_agents_half; idx_agent++ )
+    {
+        auto op = -homophily_threshold - 0.5 * idx_agent / n_agents * homophily_threshold;
+        avg_opinion += op / double( n_agents_half );
+        simulation.network.agents[idx_agent].data.opinion = op;
+    }
+
+    // second half with low opinions
+    for( size_t idx_agent = n_agents_half; idx_agent < n_agents; idx_agent++ )
+    {
+        auto op = homophily_threshold + 0.5 * ( idx_agent - n_agents_half ) / n_agents * homophily_threshold;
+        simulation.network.agents[idx_agent].data.opinion = op;
+    }
+
+    // The two halves are so far apart that they should not interact an therefore form two stable clusters.
+    simulation.run( output_dir_path );
+
+    for( size_t idx_agent = 0; idx_agent < n_agents_half; idx_agent++ )
+    {
+        REQUIRE_THAT( simulation.network.agents[idx_agent].data.opinion, WithinRel( avg_opinion ) );
+    }
+
+    for( size_t idx_agent = n_agents_half; idx_agent < n_agents; idx_agent++ )
+    {
+        REQUIRE_THAT( simulation.network.agents[idx_agent].data.opinion, WithinRel( -avg_opinion ) );
+    }
 }

--- a/test/test_deffuant.cpp
+++ b/test/test_deffuant.cpp
@@ -1,0 +1,62 @@
+#include "catch2/matchers/catch_matchers.hpp"
+#include "models/DeffuantModel.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <config_parser.hpp>
+#include <filesystem>
+#include <network_io.hpp>
+#include <optional>
+#include <simulation.hpp>
+
+namespace fs = std::filesystem;
+
+TEST_CASE( "Test the basic deffuant model for two agents", "[deffuantTwoAgents]" )
+{
+    using namespace Seldon;
+    using namespace Catch::Matchers;
+    using AgentT = DeffuantModel::AgentT;
+
+    auto proj_root_path = fs::current_path();
+    auto input_file     = proj_root_path / fs::path( "test/res/deffuant_2agents.toml" );
+
+    auto options = Config::parse_config_file( input_file.string() );
+
+    auto simulation = Simulation<AgentT>( options, std::nullopt, std::nullopt );
+
+    // We need an output path for Simulation, but we won't write anything out there
+    fs::path output_dir_path = proj_root_path / fs::path( "test/output_deffuant" );
+
+    auto model_settings      = std::get<Seldon::Config::DeffuantSettings>( options.model_settings );
+    auto mu                  = model_settings.mu;
+    auto homophily_threshold = model_settings.homophily_threshold;
+
+    // references to agent opinion
+    auto & agent1_opinion = simulation.network.agents[0].data.opinion;
+    auto & agent2_opinion = simulation.network.agents[1].data.opinion;
+
+    // agents are too far apart, we dont expect any change with the iterations
+    double agent1_init = homophily_threshold * 1.1;
+    double agent2_init = 0;
+
+    agent1_opinion = agent1_init;
+    agent2_opinion = agent2_init;
+
+    simulation.run( output_dir_path );
+
+    REQUIRE_THAT( agent1_opinion, WithinRel( agent1_init ) );
+    REQUIRE_THAT( agent2_opinion, WithinRel( agent2_init ) );
+
+    // agents are close enough, they should converge
+    agent1_init = homophily_threshold * 0.9;
+    agent2_init = 0;
+
+    agent1_opinion = agent1_init;
+    agent2_opinion = agent2_init;
+
+    simulation.run( output_dir_path );
+
+    auto n_iterations    = model_settings.max_iterations.value();
+    double expected_diff = std::pow( 1.0 - 2.0 * mu, 2 * n_iterations ) * ( agent1_init - agent2_init );
+
+    REQUIRE_THAT( agent1_opinion - agent2_opinion, WithinRel( expected_diff ) );
+}

--- a/test/test_network.cpp
+++ b/test/test_network.cpp
@@ -112,7 +112,7 @@ TEST_CASE( "Testing the network class" )
                 auto weight    = buffer_w[i_neighbour];
                 std::tuple<size_t, size_t, Network::WeightT> edge{
                     neighbour, i_agent, weight
-                };                                     // Note that i_agent and neighbour are flipped compared to before
+                }; // Note that i_agent and neighbour are flipped compared to before
                 REQUIRE( old_edges.contains( edge ) ); // can we find the transposed edge?
                 old_edges.extract( edge );             // extract the edge afterwards
             }

--- a/test/test_network.cpp
+++ b/test/test_network.cpp
@@ -112,7 +112,7 @@ TEST_CASE( "Testing the network class" )
                 auto weight    = buffer_w[i_neighbour];
                 std::tuple<size_t, size_t, Network::WeightT> edge{
                     neighbour, i_agent, weight
-                }; // Note that i_agent and neighbour are flipped compared to before
+                };                                     // Note that i_agent and neighbour are flipped compared to before
                 REQUIRE( old_edges.contains( edge ) ); // can we find the transposed edge?
                 old_edges.extract( edge );             // extract the edge afterwards
             }

--- a/test/test_network.cpp
+++ b/test/test_network.cpp
@@ -171,4 +171,29 @@ TEST_CASE( "Testing the network class" )
             REQUIRE_THAT( weights, Catch::Matchers::RangeEquals( weights_no_double_counting[i_agent] ) );
         }
     }
+
+    SECTION( "Test the generation of a square lattice neighbour list for three agents" )
+    {
+        // clang-format off
+        std::vector<std::vector<size_t>> desired_neighbour_list =  { 
+                { 2, 1, 3, 6 }, 
+                { 2, 0, 4, 7 }, 
+                { 0, 1, 5, 8 },
+                { 4, 5, 6, 0 },
+                { 5, 3, 1, 7 },
+                { 3, 4, 2, 8 },
+                { 7, 8, 3, 0 },
+                { 8, 6, 4, 1 },
+                { 7, 6, 5, 2 }, 
+            };
+        // clang-format on
+
+        auto network = Seldon::NetworkGeneration::generate_square_lattice<double>( 3 );
+
+        for( size_t i_agent = 0; i_agent < network.n_agents(); i_agent++ )
+        {
+            auto neighbours = network.get_neighbours( i_agent );
+            REQUIRE_THAT( neighbours, Catch::Matchers::UnorderedRangeEquals( desired_neighbour_list[i_agent] ) );
+        }
+    }
 }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -1,0 +1,34 @@
+#include "catch2/matchers/catch_matchers.hpp"
+#include "util/misc.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
+TEST_CASE( "Test parse_comma_separated_list", "[util_parse_list]" )
+{
+    const std::string str = "12, aa, -2.0, 10, 13.0  \n";
+
+    std::vector<double> dbl_vec{};
+    std::vector<int> int_vec{};
+
+    std::vector<double> dbl_vec_expected = { -2.0, 13.0 };
+    std::vector<int> int_vec_expected    = { 12, 10 };
+
+    auto callback = [&]( int idx_list, std::string & substr )
+    {
+        if( idx_list == 0 || idx_list == 3 )
+        {
+            int_vec.push_back( std::stoi( substr ) );
+        }
+        else if( idx_list == 2 || idx_list == 4 )
+        {
+            dbl_vec.push_back( std::stod( substr ) );
+        }
+    };
+
+    Seldon::parse_comma_separated_list( str, callback );
+
+    REQUIRE_THAT( dbl_vec, Catch::Matchers::RangeEquals( dbl_vec_expected ) );
+    REQUIRE_THAT( int_vec, Catch::Matchers::RangeEquals( int_vec_expected ) );
+}

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -1,4 +1,5 @@
 #include "catch2/matchers/catch_matchers.hpp"
+#include "util/math.hpp"
 #include "util/misc.hpp"
 
 #include <catch2/catch_test_macros.hpp>
@@ -15,8 +16,7 @@ TEST_CASE( "Test parse_comma_separated_list", "[util_parse_list]" )
     std::vector<double> dbl_vec_expected = { -2.0, 13.0 };
     std::vector<int> int_vec_expected    = { 12, 10 };
 
-    auto callback = [&]( int idx_list, std::string & substr )
-    {
+    auto callback = [&]( int idx_list, std::string & substr ) {
         if( idx_list == 0 || idx_list == 3 )
         {
             int_vec.push_back( std::stoi( substr ) );
@@ -31,4 +31,14 @@ TEST_CASE( "Test parse_comma_separated_list", "[util_parse_list]" )
 
     REQUIRE_THAT( dbl_vec, Catch::Matchers::RangeEquals( dbl_vec_expected ) );
     REQUIRE_THAT( int_vec, Catch::Matchers::RangeEquals( int_vec_expected ) );
+}
+
+TEST_CASE( "Test Hamming distance", "[util_hamming_dist]" )
+{
+    std::vector<int> v1 = { 1, 1, 1, 0, 1 };
+    std::vector<int> v2 = { 0, 1, 1, 0, 0 };
+
+    auto dist = Seldon::hamming_distance( std::span( v1 ), std::span( v2 ) );
+
+    REQUIRE( dist == 2 );
 }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -16,7 +16,8 @@ TEST_CASE( "Test parse_comma_separated_list", "[util_parse_list]" )
     std::vector<double> dbl_vec_expected = { -2.0, 13.0 };
     std::vector<int> int_vec_expected    = { 12, 10 };
 
-    auto callback = [&]( int idx_list, std::string & substr ) {
+    auto callback = [&]( int idx_list, std::string & substr )
+    {
         if( idx_list == 0 || idx_list == 3 )
         {
             int_vec.push_back( std::stoi( substr ) );


### PR DESCRIPTION
We have refactored `simulation.hpp` to handle different model creation code using `model_factory.hpp`. This means that logic branches are now confined mainly to `main.cpp` and a localized portion of `simulation.hpp`. In addition, we have implemented the basic Deffuant model, the Deffuant model on a square lattice, and a multi-dimensional Deffuant model with binary opinions.  