### PR TITLE
Output settings: Allow renumbering of output files

### DIFF
--- a/examples/ActivityDriven/conf.toml
+++ b/examples/ActivityDriven/conf.toml
@@ -8,6 +8,7 @@ n_output_agents = 1 # Write the opinions of agents after every iteration
 print_progress = true # Print the iteration time ; if not set, then does not print
 output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
 start_output = 2 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+start_numbering_from = 0 # The initial step number, before the simulation runs, is this value. The first step would be (1+start_numbering_from). By default, 0
 
 [model]
 max_iterations = 500 # If not set, max iterations is infinite

--- a/examples/ActivityDrivenBot/conf.toml
+++ b/examples/ActivityDrivenBot/conf.toml
@@ -6,8 +6,9 @@ rng_seed = 120           # Leaving this empty will pick a random seed
 n_output_network = 1  # Write the network every 20 iterations
 n_output_agents = 1 # Write the opinions of agents after every iteration
 print_progress = true # Print the iteration time; if not set, then always print
-output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
-start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+output_initial = true # Print the initial opinions and network file, before the simulation starts. If not set, this is true by default.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1 + start_numbering_from.
+start_numbering_from = 0 # The initial step number, before the simulation runs, is this value. The first step would be (1+start_numbering_from). By default, 0
 
 [model]
 max_iterations = 1000 # If not set, max iterations is infinite

--- a/examples/ActivityDrivenInertial/conf.toml
+++ b/examples/ActivityDrivenInertial/conf.toml
@@ -6,6 +6,9 @@ model = "ActivityDrivenInertial"
 n_output_network = 20 # Write the network every 20 iterations
 n_output_agents = 1   # Write the opinions of agents after every iteration
 print_progress = true # Print the iteration time ; if not set, then does not print
+output_initial = true # Print the initial opinions and network file, before the simulation starts. If not set, this is true by default.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+start_numbering_from = 0 # The initial step number, before the simulation runs, is this value. The first step would be (1+start_numbering_from). By default, 0
 
 [model]
 max_iterations = 500 # If not set, max iterations is infinite

--- a/examples/ActivityDrivenMeanField/conf.toml
+++ b/examples/ActivityDrivenMeanField/conf.toml
@@ -7,7 +7,8 @@ n_output_network = 20 # Write the network every 20 iterations
 n_output_agents = 1 # Write the opinions of agents after every iteration
 print_progress = true # Print the iteration time ; if not set, then does not print
 output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
-start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1 + start_numbering_from.
+start_numbering_from = 0 # The initial step number, before the simulation runs, is this value. The first step would be (1+start_numbering_from). By default, 0
 
 [model]
 max_iterations = 2000 # If not set, max iterations is infinite

--- a/examples/ActivityDrivenReluctance/conf.toml
+++ b/examples/ActivityDrivenReluctance/conf.toml
@@ -6,6 +6,9 @@ model = "ActivityDriven"
 n_output_network = 20 # Write the network every 20 iterations
 n_output_agents = 1   # Write the opinions of agents after every iteration
 print_progress = true # Print the iteration time ; if not set, then does not print
+output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+start_numbering_from = 0 # The initial step number, before the simulation runs, is this value. The first step would be (1+start_numbering_from). By default, 0
 
 [model]
 max_iterations = 500 # If not set, max iterations is infinite

--- a/examples/DeGroot/conf.toml
+++ b/examples/DeGroot/conf.toml
@@ -7,7 +7,8 @@ n_output_network = 20 # Write the network every 20 iterations
 n_output_agents = 1 # Write the opinions of agents after every iteration
 print_progress = false # Print the iteration time ; if not set, then does not prints
 output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
-start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1 + start_numbering_from.
+start_numbering_from = 0 # The initial step number, before the simulation runs, is this value. The first step would be (1+start_numbering_from). By default, 0
 
 [model]
 max_iterations = 20 # If not set, max iterations is infinite

--- a/examples/Deffuant/conf.toml
+++ b/examples/Deffuant/conf.toml
@@ -7,7 +7,8 @@ model = "Deffuant"
 n_output_agents = 1 # Write the opinions of agents after every iteration
 print_progress = true # Print the iteration time ; if not set, then does not prints
 output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
-start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1 + start_numbering_from.
+start_numbering_from = 0 # The initial step number, before the simulation runs, is this value. The first step would be (1+start_numbering_from). By default, 0
 
 [model]
 max_iterations = 1000 # If not set, max iterations is infinite

--- a/examples/DeffuantVector/conf.toml
+++ b/examples/DeffuantVector/conf.toml
@@ -7,7 +7,8 @@ model = "Deffuant"
 n_output_agents = 1 # Write the opinions of agents after every iteration
 print_progress = true # Print the iteration time ; if not set, then does not print
 output_initial = true # Print the initial opinions and network file from step 0. If not set, this is true by default.
-start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1.
+start_output = 1 # Start writing out opinions and/or network files from this iteration. If not set, this is 1 + start_numbering_from.
+start_numbering_from = 0 # The initial step number, before the simulation runs, is this value. The first step would be (1+start_numbering_from). By default, 0
 
 [model]
 max_iterations = 1000 # If not set, max iterations is infinite

--- a/include/config_parser.hpp
+++ b/include/config_parser.hpp
@@ -36,7 +36,9 @@ struct OutputSettings
     std::optional<size_t> n_output_network = std::nullopt;
     bool print_progress                    = false; // Print the iteration time, by default does not print
     bool output_initial                    = true;  // Output initial opinions and network, by default always outputs.
-    size_t start_output = 1; // Start printing opinion and/or network files from this iteration number
+    size_t start_output         = 1; // Start printing opinion and/or network files from this iteration number
+    size_t start_numbering_from = 0; // The initial step number, before the simulation runs, is this value. The first
+                                     // step would be (1+start_numbering_from). By default, 0
 };
 
 struct DeGrootSettings

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -107,10 +107,11 @@ public:
 
     void run( const fs::path & output_dir_path ) override
     {
-        auto n_output_agents  = this->output_settings.n_output_agents;
-        auto n_output_network = this->output_settings.n_output_network;
-        auto start_output     = this->output_settings.start_output;
-        auto output_initial   = this->output_settings.output_initial;
+        auto n_output_agents     = this->output_settings.n_output_agents;
+        auto n_output_network    = this->output_settings.n_output_network;
+        auto start_output        = this->output_settings.start_output;
+        auto initial_step_number = this->output_settings.start_numbering_from;
+        auto output_initial      = this->output_settings.output_initial;
 
         fmt::print( "-----------------------------------------------------------------\n" );
         fmt::print( "Starting simulation\n" );
@@ -118,8 +119,10 @@ public:
 
         if( output_initial )
         {
-            Seldon::network_to_file( network, ( output_dir_path / fs::path( "network_0.txt" ) ).string() );
-            auto filename = fmt::format( "opinions_{}.txt", 0 );
+            Seldon::network_to_file(
+                network,
+                ( output_dir_path / fs::path( fmt::format( "network_{}.txt", initial_step_number ) ) ).string() );
+            auto filename = fmt::format( "opinions_{}.txt", initial_step_number );
             Seldon::agents_to_file( network, ( output_dir_path / fs::path( filename ) ).string() );
         }
         this->model->initialize_iterations();
@@ -147,7 +150,7 @@ public:
             if( n_output_agents.has_value() && ( this->model->n_iterations() >= start_output )
                 && ( this->model->n_iterations() % n_output_agents.value() == 0 ) )
             {
-                auto filename = fmt::format( "opinions_{}.txt", this->model->n_iterations() );
+                auto filename = fmt::format( "opinions_{}.txt", this->model->n_iterations() + initial_step_number );
                 Seldon::agents_to_file( network, ( output_dir_path / fs::path( filename ) ).string() );
             }
 
@@ -155,7 +158,7 @@ public:
             if( n_output_network.has_value() && ( this->model->n_iterations() >= start_output )
                 && ( this->model->n_iterations() % n_output_network.value() == 0 ) )
             {
-                auto filename = fmt::format( "network_{}.txt", this->model->n_iterations() );
+                auto filename = fmt::format( "network_{}.txt", this->model->n_iterations() + initial_step_number );
                 Seldon::network_to_file( network, ( output_dir_path / fs::path( filename ) ).string() );
             }
         }

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -121,6 +121,7 @@ SimulationOptions parse_config_file( std::string_view config_file_path )
     set_if_specified( options.output_settings.print_progress, tbl["io"]["print_progress"] );
     set_if_specified( options.output_settings.output_initial, tbl["io"]["output_initial"] );
     set_if_specified( options.output_settings.start_output, tbl["io"]["start_output"] );
+    set_if_specified( options.output_settings.start_numbering_from, tbl["io"]["start_numbering_from"] );
 
     // Check if the 'model' keyword exists
     std::optional<std::string> model_string = tbl["simulation"]["model"].value<std::string>();
@@ -200,6 +201,7 @@ void validate_settings( const SimulationOptions & options )
 
     // @TODO: Check that start_output is less than the max_iterations?
     check( name_and_var( options.output_settings.start_output ), g_zero );
+    check( name_and_var( options.output_settings.start_numbering_from ), g_zero );
 
     auto validate_activity = [&]( const auto & model_settings )
     {
@@ -338,6 +340,7 @@ void print_settings( const SimulationOptions & options )
     fmt::print( "    print_progress {}\n", options.output_settings.print_progress );
     fmt::print( "    output_initial {}\n", options.output_settings.output_initial );
     fmt::print( "    start_output {}\n", options.output_settings.start_output );
+    fmt::print( "    start_numbering_from {}\n", options.output_settings.start_numbering_from );
 }
 
 } // namespace Seldon::Config


### PR DESCRIPTION
Now you can set start_numbering_from to a value greater than or equal to zero. The output files will be renumbered starting from this value.