### PR TITLE
config_parser: Fixed bug in start_numbering_from

### DIFF
--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -201,7 +201,7 @@ void validate_settings( const SimulationOptions & options )
 
     // @TODO: Check that start_output is less than the max_iterations?
     check( name_and_var( options.output_settings.start_output ), g_zero );
-    check( name_and_var( options.output_settings.start_numbering_from ), g_zero );
+    check( name_and_var( options.output_settings.start_numbering_from ), geq_zero );
 
     auto validate_activity = [&]( const auto & model_settings )
     {


### PR DESCRIPTION
The output setting, `start_numbering_from` has permissible values from 0 and greater than 0. The check in validate_settings was set to greater than 0 by mistake. Has been changed to greater than or equal to 0.