### PR TITLE
BLD: Add fmt,tomlpp subprojects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# We can store explicitly what we need
+/subprojects/
+!/subprojects/fmt.wrap
+!/subprojects/argparse.wrap
+!/subprojects/tomlplusplus.wrap
 *.txt
 
 .cache/

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,13 @@ _args = []  # Extra arguments
 
 
 _incdir += include_directories('include')
-_deps += [dependency('fmt'), dependency('tomlplusplus')]
+
+fmt_subproj = subproject('fmt', default_options: ['default_library=static'])
+_deps += fmt_subproj.get_variable('fmt_dep')
+
+tomlplusplus_subproj = subproject('tomlplusplus', default_options: ['default_library=static'])
+_deps += tomlplusplus_subproj.get_variable('tomlplusplus_dep')
+
 _args +=  cppc.get_supported_arguments(['-Wno-unused-local-typedefs', '-Wno-array-bounds'])
 
 sources_seldon = [

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ seldon_shared_dep = declare_dependency(include_directories : _incdir,
 # ------------------------------------
 
 if get_option('build_exe')
+  _deps += subproject('argparse').get_variable('argparse_dep')
   exe = executable('seldon', sources_seldon + 'src/main.cpp',
     install : true,
     dependencies : _deps,

--- a/subprojects/argparse.wrap
+++ b/subprojects/argparse.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = argparse-3.0
+source_url = https://github.com/p-ranav/argparse/archive/refs/tags/v3.0.tar.gz
+source_filename = argparse-3.0.tar.gz
+source_hash = ba7b465759bb01069d57302855eaf4d1f7d677f21ad7b0b00b92939645c30f47
+patch_filename = argparse_3.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/argparse_3.0-1/get_patch
+patch_hash = f83ed766f07c830d3922676c67959f2078a055c07bd360f19e0e114d375d1037
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/argparse_3.0-1/argparse-3.0.tar.gz
+wrapdb_version = 3.0-1
+
+[provide]
+argparse = argparse_dep

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = fmt-11.0.1
+source_url = https://github.com/fmtlib/fmt/archive/11.0.1.tar.gz
+source_filename = fmt-11.0.1.tar.gz
+source_hash = 7d009f7f89ac84c0a83f79ed602463d092fbf66763766a907c97fd02b100f5e9
+patch_filename = fmt_11.0.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_11.0.1-1/get_patch
+patch_hash = 0a8b93d1ee6d84a82d3872a9bfb4c3977d8a53f7f484d42d1f7ed63ed496d549
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_11.0.1-1/fmt-11.0.1.tar.gz
+wrapdb_version = 11.0.1-1
+
+[provide]
+fmt = fmt_dep

--- a/subprojects/tomlplusplus.wrap
+++ b/subprojects/tomlplusplus.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = tomlplusplus-3.4.0
+source_url = https://github.com/marzer/tomlplusplus/archive/v3.4.0.tar.gz
+source_filename = tomlplusplus-3.4.0.tar.gz
+source_hash = 8517f65938a4faae9ccf8ebb36631a38c1cadfb5efa85d9a72e15b9e97d25155
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/tomlplusplus_3.4.0-1/tomlplusplus-3.4.0.tar.gz
+wrapdb_version = 3.4.0-1
+
+[provide]
+dependency_names = tomlplusplus


### PR DESCRIPTION
The wrap files are simply vendored from `meson wrap install` and are used for generating "fat" (statically linked) libraries for `cibuildwheel` to make wheels out of.